### PR TITLE
Refactor: Flow coordinator 

### DIFF
--- a/StarWarsReader.xcodeproj/project.pbxproj
+++ b/StarWarsReader.xcodeproj/project.pbxproj
@@ -87,6 +87,7 @@
 		8F7E5CF523CE915900CC5A8E /* FilmCrawlView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F7E5CF423CE915900CC5A8E /* FilmCrawlView.swift */; };
 		8F7E5CF723CECEF100CC5A8E /* String+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F7E5CF623CECEF100CC5A8E /* String+Helpers.swift */; };
 		8F7E5CFB23CF4EC900CC5A8E /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 8F7E5CFA23CF4EC800CC5A8E /* README.md */; };
+		8F7E5CFD23D120D300CC5A8E /* FlowCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F7E5CFC23D120D300CC5A8E /* FlowCoordinator.swift */; };
 		8FDD8CBD23CAA1B800851267 /* SwapiResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FDD8CBC23CAA1B800851267 /* SwapiResponse.swift */; };
 		8FDD8CBF23CAB23900851267 /* FilmParsingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FDD8CBE23CAB23900851267 /* FilmParsingTests.swift */; };
 		8FDD8CCF23CB61CD00851267 /* luke.json in Resources */ = {isa = PBXBuildFile; fileRef = 8FDD8CC223CB61CD00851267 /* luke.json */; };
@@ -200,6 +201,7 @@
 		8F7E5CF423CE915900CC5A8E /* FilmCrawlView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilmCrawlView.swift; sourceTree = "<group>"; };
 		8F7E5CF623CECEF100CC5A8E /* String+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Helpers.swift"; sourceTree = "<group>"; };
 		8F7E5CFA23CF4EC800CC5A8E /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = SOURCE_ROOT; };
+		8F7E5CFC23D120D300CC5A8E /* FlowCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlowCoordinator.swift; sourceTree = "<group>"; };
 		8FDD8CBC23CAA1B800851267 /* SwapiResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwapiResponse.swift; sourceTree = "<group>"; };
 		8FDD8CBE23CAB23900851267 /* FilmParsingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilmParsingTests.swift; sourceTree = "<group>"; };
 		8FDD8CC223CB61CD00851267 /* luke.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = luke.json; sourceTree = "<group>"; };
@@ -307,6 +309,7 @@
 				8F7E5CFA23CF4EC800CC5A8E /* README.md */,
 				8F4CEAF723C95199000AAD47 /* Info.plist */,
 				8F4CEAE923C9518F000AAD47 /* AppDelegate.swift */,
+				8F7E5CFC23D120D300CC5A8E /* FlowCoordinator.swift */,
 				8F4CEAEB23C9518F000AAD47 /* SceneDelegate.swift */,
 				8F7E5CF623CECEF100CC5A8E /* String+Helpers.swift */,
 				8F4CEAEF23C95199000AAD47 /* Assets.xcassets */,
@@ -624,6 +627,7 @@
 			files = (
 				8F4CEB2023CA5217000AAD47 /* Vehicle.swift in Sources */,
 				8F4CEB1023CA255E000AAD47 /* Film.swift in Sources */,
+				8F7E5CFD23D120D300CC5A8E /* FlowCoordinator.swift in Sources */,
 				8F35A9B123CBA2AA0045DEEC /* FilmView.swift in Sources */,
 				8F7E5CCF23CDDC8100CC5A8E /* SpeciesView.swift in Sources */,
 				8F7E5CDE23CE578100CC5A8E /* StarshipViewModel.swift in Sources */,

--- a/StarWarsReader.xcodeproj/project.pbxproj
+++ b/StarWarsReader.xcodeproj/project.pbxproj
@@ -88,6 +88,7 @@
 		8F7E5CF723CECEF100CC5A8E /* String+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F7E5CF623CECEF100CC5A8E /* String+Helpers.swift */; };
 		8F7E5CFB23CF4EC900CC5A8E /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 8F7E5CFA23CF4EC800CC5A8E /* README.md */; };
 		8F7E5CFD23D120D300CC5A8E /* FlowCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F7E5CFC23D120D300CC5A8E /* FlowCoordinator.swift */; };
+		8F7E5CFF23D1D90D00CC5A8E /* HeaderButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F7E5CFE23D1D90D00CC5A8E /* HeaderButton.swift */; };
 		8FDD8CBD23CAA1B800851267 /* SwapiResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FDD8CBC23CAA1B800851267 /* SwapiResponse.swift */; };
 		8FDD8CBF23CAB23900851267 /* FilmParsingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FDD8CBE23CAB23900851267 /* FilmParsingTests.swift */; };
 		8FDD8CCF23CB61CD00851267 /* luke.json in Resources */ = {isa = PBXBuildFile; fileRef = 8FDD8CC223CB61CD00851267 /* luke.json */; };
@@ -202,6 +203,7 @@
 		8F7E5CF623CECEF100CC5A8E /* String+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Helpers.swift"; sourceTree = "<group>"; };
 		8F7E5CFA23CF4EC800CC5A8E /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = SOURCE_ROOT; };
 		8F7E5CFC23D120D300CC5A8E /* FlowCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlowCoordinator.swift; sourceTree = "<group>"; };
+		8F7E5CFE23D1D90D00CC5A8E /* HeaderButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderButton.swift; sourceTree = "<group>"; };
 		8FDD8CBC23CAA1B800851267 /* SwapiResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwapiResponse.swift; sourceTree = "<group>"; };
 		8FDD8CBE23CAB23900851267 /* FilmParsingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilmParsingTests.swift; sourceTree = "<group>"; };
 		8FDD8CC223CB61CD00851267 /* luke.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = luke.json; sourceTree = "<group>"; };
@@ -280,6 +282,7 @@
 				8F35A9B023CBA2AA0045DEEC /* FilmView.swift */,
 				8F35A9B223CBA2B30045DEEC /* FilmViewModel.swift */,
 				8F7E5CAE23CD516A00CC5A8E /* FilmViewSection.swift */,
+				8F7E5CFE23D1D90D00CC5A8E /* HeaderButton.swift */,
 				8F7E5CAC23CD49EB00CC5A8E /* NavigationDestination.swift */,
 			);
 			path = FilmView;
@@ -677,6 +680,7 @@
 				8F7E5CF123CE854000CC5A8E /* VehicleFilmRowView.swift in Sources */,
 				8F7E5CA723CD3D2100CC5A8E /* PersonFilmRowView.swift in Sources */,
 				8F7E5CF323CE871C00CC5A8E /* VehiclePilotRowView.swift in Sources */,
+				8F7E5CFF23D1D90D00CC5A8E /* HeaderButton.swift in Sources */,
 				8F7E5CA123CD39D300CC5A8E /* StarshipRowView.swift in Sources */,
 				8F4AEEEF23CA9C11005B27C8 /* Data.swift in Sources */,
 				8F35A99923CB6B930045DEEC /* DataFetcher.swift in Sources */,

--- a/StarWarsReader/Data/Data.swift
+++ b/StarWarsReader/Data/Data.swift
@@ -8,38 +8,104 @@
 
 import Foundation
 
+enum FilmSampleData {
+  case newHope
+
+  var fileName: String {
+    switch self {
+    case .newHope:
+      return "newHope"
+    }
+  }
+}
+
+enum PersonSampleData {
+  case luke
+
+  var fileName: String {
+    switch self {
+    case .luke:
+      return "luke"
+    }
+  }
+}
+
+enum PlanetSampleData {
+  case tatooine
+
+  var fileName: String {
+    switch self {
+    case .tatooine:
+      return "tatooine"
+    }
+  }
+}
+
+enum SpeciesSampledata {
+  case twilek
+
+  var fileName: String {
+    switch self {
+    case .twilek:
+      return "twilek"
+    }
+  }
+}
+
+enum StarshipSampleData {
+  case falcon
+
+  var fileName: String {
+    switch self {
+    case .falcon:
+      return "falcon"
+    }
+  }
+}
+
+enum VehicleSampleData {
+  case airspeeder
+
+  var fileName: String {
+    switch self {
+    case .airspeeder:
+      return "airspeeder"
+    }
+  }
+}
+
 var sampleFilms: [FilmsResponse.Film] {
   let response: SwapiResponse<FilmsResponse> = load("allFilms")
   return response.data.allFilms
 }
 
-func loadSampleFilm(_ name: String) -> Film {
-  let response: SwapiResponse<FilmQueryResponse> = load(name)
+func loadSampleFilm(_ sampleData: FilmSampleData) -> Film {
+  let response: SwapiResponse<FilmQueryResponse> = load(sampleData.fileName)
   return response.data.film
 }
 
-func loadSamplePerson(_ name: String) -> Person {
-  let response: SwapiResponse<PersonQueryResponse> = load(name)
+func loadSamplePerson(_ sampleData: PersonSampleData) -> Person {
+  let response: SwapiResponse<PersonQueryResponse> = load(sampleData.fileName)
   return response.data.person
 }
 
-func loadSamplePlanet(_ name: String) -> Planet {
-  let response: SwapiResponse<PlanetQueryResponse> = load(name)
+func loadSamplePlanet(_ sampleData: PlanetSampleData) -> Planet {
+  let response: SwapiResponse<PlanetQueryResponse> = load(sampleData.fileName)
   return response.data.planet
 }
 
-func loadSampleSpecies(_ name: String) -> Species {
-  let response: SwapiResponse<SpeciesQueryResponse> = load(name)
+func loadSampleSpecies(_ sampleData: SpeciesSampledata) -> Species {
+  let response: SwapiResponse<SpeciesQueryResponse> = load(sampleData.fileName)
   return response.data.species
 }
 
-func loadSampleStarship(_ name: String) -> Starship {
-  let response: SwapiResponse<StarshipQueryResponse> = load(name)
+func loadSampleStarship(_ sampleData: StarshipSampleData) -> Starship {
+  let response: SwapiResponse<StarshipQueryResponse> = load(sampleData.fileName)
   return response.data.starship
 }
 
-func loadSampleVehicle(_ name: String) -> Vehicle {
-  let response: SwapiResponse<VehicleQueryResponse> = load(name)
+func loadSampleVehicle(_ sampleData: VehicleSampleData) -> Vehicle {
+  let response: SwapiResponse<VehicleQueryResponse> = load(sampleData.fileName)
   return response.data.vehicle
 }
 

--- a/StarWarsReader/FilmView/CharacterListView.swift
+++ b/StarWarsReader/FilmView/CharacterListView.swift
@@ -12,8 +12,13 @@ struct CharacterListViewModel {
 
   let characters: [Film.Character]
 
+  let characterViewInitializer: CharacterViewInitializer
+
   func viewModel(forCharacter character: Film.Character) -> CharacterRowViewModel {
-    return CharacterRowViewModel(character: character)
+    return CharacterRowViewModel(
+      character: character,
+      personView: characterViewInitializer(character)
+    )
   }
 }
 
@@ -33,16 +38,22 @@ struct CharacterListView: View {
   }
 }
 
+extension CharacterListView {
+  static var mock: CharacterListView {
+    let newHope = loadSampleFilm("newHope")
+    let viewModel = CharacterListViewModel(
+      characters: newHope.characters,
+      characterViewInitializer: { _ in PersonView.mock }
+    )
+    return CharacterListView(viewModel: viewModel)
+  }
+}
+
 // swiftlint:disable all
 struct CharacterListView_Previews: PreviewProvider {
-  static let vm: CharacterListViewModel = {
-    let film = loadSampleFilm("newHope")
-    return CharacterListViewModel(characters: film.characters)
-  }()
-
   static var previews: some View {
     NavigationView {
-      CharacterListView(viewModel: vm)
+      CharacterListView.mock
     }
   }
 }

--- a/StarWarsReader/FilmView/CharacterListView.swift
+++ b/StarWarsReader/FilmView/CharacterListView.swift
@@ -40,7 +40,7 @@ struct CharacterListView: View {
 
 extension CharacterListView {
   static var mock: CharacterListView {
-    let newHope = loadSampleFilm("newHope")
+    let newHope = loadSampleFilm(.newHope)
     let viewModel = CharacterListViewModel(
       characters: newHope.characters,
       characterViewInitializer: { _ in PersonView.mock }

--- a/StarWarsReader/FilmView/CharacterRowView.swift
+++ b/StarWarsReader/FilmView/CharacterRowView.swift
@@ -23,7 +23,8 @@ struct CharacterRowViewModel {
     PersonViewModel(
       resourceId: character.characterId,
       homeworldView: { _ in PlanetView.mock },
-      speciesView: { _ in SpeciesView.mock }
+      speciesView: { _ in SpeciesView.mock },
+      filmView: { _ in FilmView.mock }
     )
   }
 }

--- a/StarWarsReader/FilmView/CharacterRowView.swift
+++ b/StarWarsReader/FilmView/CharacterRowView.swift
@@ -36,7 +36,7 @@ struct CharacterRowView: View {
 
 extension CharacterRowView {
   static var mock: CharacterRowView {
-    let film = loadSampleFilm("newHope")
+    let film = loadSampleFilm(.newHope)
     let viewModel = CharacterRowViewModel(
       character: film.characters[0],
       personView: PersonView.mock

--- a/StarWarsReader/FilmView/CharacterRowView.swift
+++ b/StarWarsReader/FilmView/CharacterRowView.swift
@@ -19,7 +19,8 @@ struct CharacterRowViewModel {
   }
 
   var personViewModel: PersonViewModel {
-    PersonViewModel(resourceId: character.characterId)
+    // TODO: refactor mock value 
+    PersonViewModel(resourceId: character.characterId, homeworldView: { _ in PlanetView.mock })
   }
 }
 

--- a/StarWarsReader/FilmView/CharacterRowView.swift
+++ b/StarWarsReader/FilmView/CharacterRowView.swift
@@ -20,7 +20,11 @@ struct CharacterRowViewModel {
 
   var personViewModel: PersonViewModel {
     // TODO: refactor mock value 
-    PersonViewModel(resourceId: character.characterId, homeworldView: { _ in PlanetView.mock })
+    PersonViewModel(
+      resourceId: character.characterId,
+      homeworldView: { _ in PlanetView.mock },
+      speciesView: { _ in SpeciesView.mock }
+    )
   }
 }
 

--- a/StarWarsReader/FilmView/CharacterRowView.swift
+++ b/StarWarsReader/FilmView/CharacterRowView.swift
@@ -26,9 +26,7 @@ struct CharacterRowView: View {
   let viewModel: CharacterRowViewModel
 
   var body: some View {
-    NavigationLink(destination: PersonView(viewModel: viewModel.personViewModel)) {
-      Text(viewModel.name)
-    }
+    Text(viewModel.name)
   }
 }
 

--- a/StarWarsReader/FilmView/CharacterRowView.swift
+++ b/StarWarsReader/FilmView/CharacterRowView.swift
@@ -17,18 +17,6 @@ struct CharacterRowViewModel {
   var name: String {
     character.name
   }
-
-  var personViewModel: PersonViewModel {
-    // TODO: refactor mock value 
-    PersonViewModel(
-      resourceId: character.characterId,
-      homeworldView: { _ in PlanetView.mock },
-      speciesView: { _ in SpeciesView.mock },
-      filmView: { _ in FilmView.mock },
-      starshipView: { _ in StarshipView.mock },
-      vehicleView: { _ in VehicleView.mock }
-    )
-  }
 }
 
 struct CharacterRowView: View {

--- a/StarWarsReader/FilmView/CharacterRowView.swift
+++ b/StarWarsReader/FilmView/CharacterRowView.swift
@@ -25,7 +25,8 @@ struct CharacterRowViewModel {
       homeworldView: { _ in PlanetView.mock },
       speciesView: { _ in SpeciesView.mock },
       filmView: { _ in FilmView.mock },
-      starshipView: { _ in StarshipView.mock }
+      starshipView: { _ in StarshipView.mock },
+      vehicleView: { _ in VehicleView.mock }
     )
   }
 }

--- a/StarWarsReader/FilmView/CharacterRowView.swift
+++ b/StarWarsReader/FilmView/CharacterRowView.swift
@@ -24,7 +24,8 @@ struct CharacterRowViewModel {
       resourceId: character.characterId,
       homeworldView: { _ in PlanetView.mock },
       speciesView: { _ in SpeciesView.mock },
-      filmView: { _ in FilmView.mock }
+      filmView: { _ in FilmView.mock },
+      starshipView: { _ in StarshipView.mock }
     )
   }
 }

--- a/StarWarsReader/FilmView/CharacterRowView.swift
+++ b/StarWarsReader/FilmView/CharacterRowView.swift
@@ -12,6 +12,8 @@ struct CharacterRowViewModel {
 
   let character: Film.Character
 
+  let personView: PersonView
+
   var name: String {
     character.name
   }
@@ -26,18 +28,26 @@ struct CharacterRowView: View {
   let viewModel: CharacterRowViewModel
 
   var body: some View {
-    Text(viewModel.name)
+    NavigationLink(destination: viewModel.personView) {
+      Text(viewModel.name)
+    }
+  }
+}
+
+extension CharacterRowView {
+  static var mock: CharacterRowView {
+    let film = loadSampleFilm("newHope")
+    let viewModel = CharacterRowViewModel(
+      character: film.characters[0],
+      personView: PersonView.mock
+    )
+    return CharacterRowView(viewModel: viewModel)
   }
 }
 
 // swiftlint:disable all
 struct CharacterRowView_Previews: PreviewProvider {
-  static let vm: CharacterRowViewModel = {
-    let film = loadSampleFilm("newHope")
-    return CharacterRowViewModel(character: film.characters.first!)
-  }()
-
   static var previews: some View {
-    CharacterRowView(viewModel: vm)
+    CharacterRowView.mock
   }
 }

--- a/StarWarsReader/FilmView/FilmCrawlView.swift
+++ b/StarWarsReader/FilmView/FilmCrawlView.swift
@@ -39,7 +39,7 @@ struct FilmCrawlView: View {
 // swiftlint:disable all
 struct FilmCrawlView_Previews: PreviewProvider {
   static let vm: FilmCrawlViewModel = {
-    let film = loadSampleFilm("newHope")
+    let film = loadSampleFilm(.newHope)
     return FilmCrawlViewModel(film: film)
   }()
 

--- a/StarWarsReader/FilmView/FilmPlanetListView.swift
+++ b/StarWarsReader/FilmView/FilmPlanetListView.swift
@@ -12,8 +12,13 @@ struct FilmPlanetListViewModel {
 
   let planets: [Film.Planet]
 
+  let planetView: FilmPlanetViewInitializer = { _ in PlanetView.mock }
+
   func viewModel(forPlanet planet: Film.Planet) -> FilmPlanetRowViewModel {
-    FilmPlanetRowViewModel(planet: planet)
+    FilmPlanetRowViewModel(
+      planet: planet,
+      planetView: planetView(planet)
+    )
   }
 
   var viewTitle: String {

--- a/StarWarsReader/FilmView/FilmPlanetListView.swift
+++ b/StarWarsReader/FilmView/FilmPlanetListView.swift
@@ -12,7 +12,7 @@ struct FilmPlanetListViewModel {
 
   let planets: [Film.Planet]
 
-  let planetView: FilmPlanetViewInitializer = { _ in PlanetView.mock }
+  let planetView: FilmPlanetViewInitializer
 
   func viewModel(forPlanet planet: Film.Planet) -> FilmPlanetRowViewModel {
     FilmPlanetRowViewModel(
@@ -40,16 +40,19 @@ struct FilmPlanetListView: View {
   }
 }
 
-// swiftlint:disable all
-struct PlanetListView_Previews: PreviewProvider {
-  static let vm: FilmPlanetListViewModel = {
-    let film = loadSampleFilm("newHope")
-    return FilmPlanetListViewModel(planets: film.planets)
-  }()
+extension FilmPlanetListView {
+  static var mock: FilmPlanetListView {
+    let filmPlanets = loadSampleFilm("newHope").planets
+    let viewModel = FilmPlanetListViewModel(planets: filmPlanets, planetView: { _ in PlanetView.mock })
+    return FilmPlanetListView(viewModel: viewModel)
+  }
+}
 
+// swiftlint:disable all
+struct FilmPlanetListView_Previews: PreviewProvider {
   static var previews: some View {
     NavigationView {
-      FilmPlanetListView(viewModel: vm)
+      FilmPlanetListView.mock
     }
   }
 }

--- a/StarWarsReader/FilmView/FilmPlanetListView.swift
+++ b/StarWarsReader/FilmView/FilmPlanetListView.swift
@@ -42,7 +42,7 @@ struct FilmPlanetListView: View {
 
 extension FilmPlanetListView {
   static var mock: FilmPlanetListView {
-    let filmPlanets = loadSampleFilm("newHope").planets
+    let filmPlanets = loadSampleFilm(.newHope).planets
     let viewModel = FilmPlanetListViewModel(planets: filmPlanets, planetView: { _ in PlanetView.mock })
     return FilmPlanetListView(viewModel: viewModel)
   }

--- a/StarWarsReader/FilmView/FilmPlanetRowView.swift
+++ b/StarWarsReader/FilmView/FilmPlanetRowView.swift
@@ -36,7 +36,7 @@ struct FilmPlanetRowView: View {
 
 extension FilmPlanetRowView {
   static var mock: FilmPlanetRowView {
-    let filmPlanet = loadSampleFilm("newHope").planets[0]
+    let filmPlanet = loadSampleFilm(.newHope).planets[0]
     let viewModel = FilmPlanetRowViewModel(
       planet: filmPlanet,
       planetView: PlanetView.mock

--- a/StarWarsReader/FilmView/FilmPlanetRowView.swift
+++ b/StarWarsReader/FilmView/FilmPlanetRowView.swift
@@ -26,9 +26,7 @@ struct FilmPlanetRowView: View {
   let viewModel: FilmPlanetRowViewModel
 
   var body: some View {
-    NavigationLink(destination: PlanetView(viewModel: viewModel.planetViewModel)) {
-      Text(viewModel.name)
-    }
+    Text(viewModel.name)
   }
 }
 

--- a/StarWarsReader/FilmView/FilmPlanetRowView.swift
+++ b/StarWarsReader/FilmView/FilmPlanetRowView.swift
@@ -19,7 +19,8 @@ struct FilmPlanetRowViewModel {
   }
 
   var planetViewModel: PlanetViewModel {
-    PlanetViewModel(planetId: planet.planetId)
+    // TODO: refactor the mock values here 
+    PlanetViewModel(planetId: planet.planetId, planetFilmView: { _ in FilmView.mock })
   }
 }
 

--- a/StarWarsReader/FilmView/FilmPlanetRowView.swift
+++ b/StarWarsReader/FilmView/FilmPlanetRowView.swift
@@ -12,6 +12,8 @@ struct FilmPlanetRowViewModel {
 
   let planet: Film.Planet
 
+  let planetView: PlanetView
+
   var name: String {
     planet.name
   }
@@ -26,18 +28,26 @@ struct FilmPlanetRowView: View {
   let viewModel: FilmPlanetRowViewModel
 
   var body: some View {
-    Text(viewModel.name)
+    NavigationLink(destination: viewModel.planetView) {
+      Text(viewModel.name)
+    }
+  }
+}
+
+extension FilmPlanetRowView {
+  static var mock: FilmPlanetRowView {
+    let filmPlanet = loadSampleFilm("newHope").planets[0]
+    let viewModel = FilmPlanetRowViewModel(
+      planet: filmPlanet,
+      planetView: PlanetView.mock
+    )
+    return FilmPlanetRowView(viewModel: viewModel)
   }
 }
 
 // swiftlint:disable all
 struct FilmPlanetRowView_Previews: PreviewProvider {
-  static let vm: FilmPlanetRowViewModel = {
-    let film = loadSampleFilm("newHope")
-    return FilmPlanetRowViewModel(planet: film.planets.first!)
-  }()
-
   static var previews: some View {
-    FilmPlanetRowView(viewModel: vm)
+    FilmPlanetRowView.mock
   }
 }

--- a/StarWarsReader/FilmView/FilmPlanetRowView.swift
+++ b/StarWarsReader/FilmView/FilmPlanetRowView.swift
@@ -20,7 +20,11 @@ struct FilmPlanetRowViewModel {
 
   var planetViewModel: PlanetViewModel {
     // TODO: refactor the mock values here 
-    PlanetViewModel(planetId: planet.planetId, planetFilmView: { _ in FilmView.mock })
+    PlanetViewModel(
+      planetId: planet.planetId,
+      planetFilmView: { _ in FilmView.mock },
+      residentView: { _ in PersonView.mock }
+    )
   }
 }
 

--- a/StarWarsReader/FilmView/FilmPlanetRowView.swift
+++ b/StarWarsReader/FilmView/FilmPlanetRowView.swift
@@ -17,15 +17,6 @@ struct FilmPlanetRowViewModel {
   var name: String {
     planet.name
   }
-
-  var planetViewModel: PlanetViewModel {
-    // TODO: refactor the mock values here 
-    PlanetViewModel(
-      planetId: planet.planetId,
-      planetFilmView: { _ in FilmView.mock },
-      residentView: { _ in PersonView.mock }
-    )
-  }
 }
 
 struct FilmPlanetRowView: View {

--- a/StarWarsReader/FilmView/FilmSpeciesListView.swift
+++ b/StarWarsReader/FilmView/FilmSpeciesListView.swift
@@ -12,10 +12,12 @@ struct FilmSpeciesListViewModel {
 
   let species: [Film.Species]
 
+  let speciesView: FilmSpeciesViewInitializer
+
   func viewModel(for species: Film.Species) -> FilmSpeciesRowViewModel {
     FilmSpeciesRowViewModel(
       species: species,
-      speciesView: SpeciesView.mock
+      speciesView: speciesView(species)
     )
   }
 }
@@ -34,16 +36,22 @@ struct FilmSpeciesListView: View {
   }
 }
 
+extension FilmSpeciesListView {
+  static var mock: FilmSpeciesListView {
+    let filmSpecies = loadSampleFilm("newHope").species
+    let viewModel = FilmSpeciesListViewModel(
+      species: filmSpecies,
+      speciesView: { _ in SpeciesView.mock }
+    )
+    return FilmSpeciesListView(viewModel: viewModel)
+  }
+}
+
 // swiftlint:disable all
 struct FilmSpeciesListView_Previews: PreviewProvider {
-  static let vm: FilmSpeciesListViewModel = {
-    let newHope = loadSampleFilm("newHope")
-    return FilmSpeciesListViewModel(species: newHope.species)
-  }()
-
   static var previews: some View {
     NavigationView {
-      FilmSpeciesListView(viewModel: vm)
+      FilmSpeciesListView.mock
     }
   }
 }

--- a/StarWarsReader/FilmView/FilmSpeciesListView.swift
+++ b/StarWarsReader/FilmView/FilmSpeciesListView.swift
@@ -13,7 +13,10 @@ struct FilmSpeciesListViewModel {
   let species: [Film.Species]
 
   func viewModel(for species: Film.Species) -> FilmSpeciesRowViewModel {
-    FilmSpeciesRowViewModel(species: species)
+    FilmSpeciesRowViewModel(
+      species: species,
+      speciesView: SpeciesView.mock
+    )
   }
 }
 

--- a/StarWarsReader/FilmView/FilmSpeciesListView.swift
+++ b/StarWarsReader/FilmView/FilmSpeciesListView.swift
@@ -38,7 +38,7 @@ struct FilmSpeciesListView: View {
 
 extension FilmSpeciesListView {
   static var mock: FilmSpeciesListView {
-    let filmSpecies = loadSampleFilm("newHope").species
+    let filmSpecies = loadSampleFilm(.newHope).species
     let viewModel = FilmSpeciesListViewModel(
       species: filmSpecies,
       speciesView: { _ in SpeciesView.mock }

--- a/StarWarsReader/FilmView/FilmSpeciesRowView.swift
+++ b/StarWarsReader/FilmView/FilmSpeciesRowView.swift
@@ -12,13 +12,12 @@ struct FilmSpeciesRowViewModel {
 
   let species: Film.Species
 
+  let speciesView: SpeciesView
+
   var name: String {
     species.name
   }
 
-  var speciesViewModel: SpeciesViewModel {
-    SpeciesViewModel(resourceId: species.speciesId)
-  }
 }
 
 struct FilmSpeciesRowView: View {
@@ -26,18 +25,23 @@ struct FilmSpeciesRowView: View {
   let viewModel: FilmSpeciesRowViewModel
 
   var body: some View {
-    Text(viewModel.name)
+    NavigationLink(destination: viewModel.speciesView) {
+      Text(viewModel.name)
+    }
+  }
+}
+
+extension FilmSpeciesRowView {
+  static var mock: FilmSpeciesRowView {
+    let filmSpecies = loadSampleFilm("newHope").species[0]
+    let viewModel = FilmSpeciesRowViewModel(species: filmSpecies, speciesView: SpeciesView.mock)
+    return FilmSpeciesRowView(viewModel: viewModel)
   }
 }
 
 // swiftlint:disable all
 struct FilmSpeciesRowView_Previews: PreviewProvider {
-  static let vm: FilmSpeciesRowViewModel = {
-    let newHope = loadSampleFilm("newHope")
-    return FilmSpeciesRowViewModel(species: newHope.species.first!)
-  }()
-
   static var previews: some View {
-    FilmSpeciesRowView(viewModel: vm)
+    FilmSpeciesRowView.mock
   }
 }

--- a/StarWarsReader/FilmView/FilmSpeciesRowView.swift
+++ b/StarWarsReader/FilmView/FilmSpeciesRowView.swift
@@ -33,7 +33,7 @@ struct FilmSpeciesRowView: View {
 
 extension FilmSpeciesRowView {
   static var mock: FilmSpeciesRowView {
-    let filmSpecies = loadSampleFilm("newHope").species[0]
+    let filmSpecies = loadSampleFilm(.newHope).species[0]
     let viewModel = FilmSpeciesRowViewModel(species: filmSpecies, speciesView: SpeciesView.mock)
     return FilmSpeciesRowView(viewModel: viewModel)
   }

--- a/StarWarsReader/FilmView/FilmSpeciesRowView.swift
+++ b/StarWarsReader/FilmView/FilmSpeciesRowView.swift
@@ -26,9 +26,7 @@ struct FilmSpeciesRowView: View {
   let viewModel: FilmSpeciesRowViewModel
 
   var body: some View {
-    NavigationLink(destination: SpeciesView(viewModel: viewModel.speciesViewModel)) {
-      Text(viewModel.name)
-    }
+    Text(viewModel.name)
   }
 }
 

--- a/StarWarsReader/FilmView/FilmStarshipListView.swift
+++ b/StarWarsReader/FilmView/FilmStarshipListView.swift
@@ -12,8 +12,13 @@ struct FilmStarshipListViewModel {
 
   let starships: [Film.Starship]
 
+  let filmStarshipView: FilmStarshipViewInitializer
+
   func viewModel(forStarship starship: Film.Starship) -> FilmStarshipRowViewModel {
-    FilmStarshipRowViewModel(starship: starship, starshipView: StarshipView.mock)
+    FilmStarshipRowViewModel(
+      starship: starship,
+      starshipView: filmStarshipView(starship)
+    )
   }
 }
 
@@ -33,16 +38,19 @@ struct FilmStarshipListView: View {
   }
 }
 
+extension FilmStarshipListView {
+  static var mock: FilmStarshipListView {
+    let starships = loadSampleFilm(.newHope).starships
+    let viewModel = FilmStarshipListViewModel(starships: starships, filmStarshipView: { _ in StarshipView.mock })
+    return FilmStarshipListView(viewModel: viewModel)
+  }
+}
+
 //swiftlint:disable all
 struct FilmStarshipListView_Previews: PreviewProvider {
-  static let vm: FilmStarshipListViewModel = {
-    let newHope = loadSampleFilm(.newHope)
-    return FilmStarshipListViewModel(starships: newHope.starships)
-  }()
-
   static var previews: some View {
     NavigationView {
-      FilmStarshipListView(viewModel: vm)
+      FilmStarshipListView.mock
     }
   }
 }

--- a/StarWarsReader/FilmView/FilmStarshipListView.swift
+++ b/StarWarsReader/FilmView/FilmStarshipListView.swift
@@ -13,7 +13,7 @@ struct FilmStarshipListViewModel {
   let starships: [Film.Starship]
 
   func viewModel(forStarship starship: Film.Starship) -> FilmStarshipRowViewModel {
-    FilmStarshipRowViewModel(starship: starship)
+    FilmStarshipRowViewModel(starship: starship, starshipView: StarshipView.mock)
   }
 }
 

--- a/StarWarsReader/FilmView/FilmStarshipListView.swift
+++ b/StarWarsReader/FilmView/FilmStarshipListView.swift
@@ -36,7 +36,7 @@ struct FilmStarshipListView: View {
 //swiftlint:disable all
 struct FilmStarshipListView_Previews: PreviewProvider {
   static let vm: FilmStarshipListViewModel = {
-    let newHope = loadSampleFilm("newHope")
+    let newHope = loadSampleFilm(.newHope)
     return FilmStarshipListViewModel(starships: newHope.starships)
   }()
 

--- a/StarWarsReader/FilmView/FilmStarshipRowView.swift
+++ b/StarWarsReader/FilmView/FilmStarshipRowView.swift
@@ -26,9 +26,7 @@ struct FilmStarshipRowView: View {
   let viewModel: FilmStarshipRowViewModel
 
   var body: some View {
-    NavigationLink(destination: StarshipView(viewModel: viewModel.starshipViewModel)) {
-      Text(viewModel.name)
-    }
+    Text(viewModel.name)
   }
 }
 

--- a/StarWarsReader/FilmView/FilmStarshipRowView.swift
+++ b/StarWarsReader/FilmView/FilmStarshipRowView.swift
@@ -12,12 +12,10 @@ struct FilmStarshipRowViewModel {
 
   let starship: Film.Starship
 
+  let starshipView: StarshipView
+
   var name: String {
     starship.name
-  }
-
-  var starshipViewModel: StarshipViewModel {
-    StarshipViewModel(resourceId: starship.starshipId)
   }
 }
 
@@ -26,18 +24,23 @@ struct FilmStarshipRowView: View {
   let viewModel: FilmStarshipRowViewModel
 
   var body: some View {
-    Text(viewModel.name)
+    NavigationLink(destination: viewModel.starshipView) {
+      Text(viewModel.name)
+    }
+  }
+}
+
+extension FilmStarshipRowView {
+  static var mock: FilmStarshipRowView {
+    let filmStarship = loadSampleFilm(.newHope).starships[0]
+    let viewModel = FilmStarshipRowViewModel(starship: filmStarship, starshipView: StarshipView.mock)
+    return FilmStarshipRowView(viewModel: viewModel)
   }
 }
 
 // swiftlint:disable all
 struct FilmStarshipRowView_Previews: PreviewProvider {
-  static let vm: FilmStarshipRowViewModel = {
-    let newHope = loadSampleFilm(.newHope)
-    return FilmStarshipRowViewModel(starship: newHope.starships.first!)
-  }()
-
   static var previews: some View {
-    FilmStarshipRowView(viewModel: vm)
+    FilmStarshipRowView.mock
   }
 }

--- a/StarWarsReader/FilmView/FilmStarshipRowView.swift
+++ b/StarWarsReader/FilmView/FilmStarshipRowView.swift
@@ -33,7 +33,7 @@ struct FilmStarshipRowView: View {
 // swiftlint:disable all
 struct FilmStarshipRowView_Previews: PreviewProvider {
   static let vm: FilmStarshipRowViewModel = {
-    let newHope = loadSampleFilm("newHope")
+    let newHope = loadSampleFilm(.newHope)
     return FilmStarshipRowViewModel(starship: newHope.starships.first!)
   }()
 

--- a/StarWarsReader/FilmView/FilmVehicleListView.swift
+++ b/StarWarsReader/FilmView/FilmVehicleListView.swift
@@ -34,7 +34,7 @@ struct FilmVehicleListView: View {
 // swiftlint:disable all
 struct FilmVehicleListView_Previews: PreviewProvider {
   static let vm: FilmVehicleListViewModel = {
-    let newHope = loadSampleFilm("newHope")
+    let newHope = loadSampleFilm(.newHope)
     return FilmVehicleListViewModel(vehicles: newHope.vehicles)
   }()
 

--- a/StarWarsReader/FilmView/FilmVehicleListView.swift
+++ b/StarWarsReader/FilmView/FilmVehicleListView.swift
@@ -12,7 +12,7 @@ struct FilmVehicleListViewModel {
 
   let vehicles: [Film.Vehicle]
 
-  let vehicleView: FilmVehicleViewInitializer = { _ in VehicleView.mock }
+  let vehicleView: FilmVehicleViewInitializer
 
   func viewModel(forVehicle vehicle: Film.Vehicle) -> FilmVehicleRowViewModel {
     FilmVehicleRowViewModel(vehicle: vehicle, vehicleView: vehicleView(vehicle))
@@ -33,16 +33,22 @@ struct FilmVehicleListView: View {
   }
 }
 
+extension FilmVehicleListView {
+  static var mock: FilmVehicleListView {
+    let filmVehicles = loadSampleFilm(.newHope).vehicles
+    let viewModel = FilmVehicleListViewModel(
+      vehicles: filmVehicles,
+      vehicleView: { _ in VehicleView.mock }
+    )
+    return FilmVehicleListView(viewModel: viewModel)
+  }
+}
+
 // swiftlint:disable all
 struct FilmVehicleListView_Previews: PreviewProvider {
-  static let vm: FilmVehicleListViewModel = {
-    let newHope = loadSampleFilm(.newHope)
-    return FilmVehicleListViewModel(vehicles: newHope.vehicles)
-  }()
-
   static var previews: some View {
     NavigationView {
-      FilmVehicleListView(viewModel: vm)
+      FilmVehicleListView.mock
     }
   }
 }

--- a/StarWarsReader/FilmView/FilmVehicleListView.swift
+++ b/StarWarsReader/FilmView/FilmVehicleListView.swift
@@ -12,8 +12,10 @@ struct FilmVehicleListViewModel {
 
   let vehicles: [Film.Vehicle]
 
+  let vehicleView: FilmVehicleViewInitializer = { _ in VehicleView.mock }
+
   func viewModel(forVehicle vehicle: Film.Vehicle) -> FilmVehicleRowViewModel {
-    FilmVehicleRowViewModel(vehicle: vehicle)
+    FilmVehicleRowViewModel(vehicle: vehicle, vehicleView: vehicleView(vehicle))
   }
 }
 

--- a/StarWarsReader/FilmView/FilmVehicleRowView.swift
+++ b/StarWarsReader/FilmView/FilmVehicleRowView.swift
@@ -12,12 +12,10 @@ struct FilmVehicleRowViewModel {
 
   let vehicle: Film.Vehicle
 
+  let vehicleView: VehicleView
+
   var name: String {
     vehicle.name
-  }
-
-  var vehicleViewModel: VehicleViewModel {
-    VehicleViewModel(resourceId: vehicle.vehicleId)
   }
 }
 
@@ -26,18 +24,23 @@ struct FilmVehicleRowView: View {
   let viewModel: FilmVehicleRowViewModel
 
   var body: some View {
-    Text(viewModel.name)
+    NavigationLink(destination: viewModel.vehicleView) {
+      Text(viewModel.name)
+    }
+  }
+}
+
+extension FilmVehicleRowView {
+  static var mock: FilmVehicleRowView {
+    let filmVehicle = loadSampleFilm(.newHope).vehicles[0]
+    let viewModel = FilmVehicleRowViewModel(vehicle: filmVehicle, vehicleView: VehicleView.mock)
+    return FilmVehicleRowView(viewModel: viewModel)
   }
 }
 
 // swiftlint:disable all
 struct FilmVehicleRowView_Previews: PreviewProvider {
-  static let vm: FilmVehicleRowViewModel = {
-    let newHope = loadSampleFilm(.newHope)
-    return FilmVehicleRowViewModel(vehicle: newHope.vehicles.first!)
-  }()
-  
   static var previews: some View {
-    FilmVehicleRowView(viewModel: vm)
+    FilmVehicleRowView.mock
   }
 }

--- a/StarWarsReader/FilmView/FilmVehicleRowView.swift
+++ b/StarWarsReader/FilmView/FilmVehicleRowView.swift
@@ -26,9 +26,7 @@ struct FilmVehicleRowView: View {
   let viewModel: FilmVehicleRowViewModel
 
   var body: some View {
-    NavigationLink(destination: VehicleView(viewModel: viewModel.vehicleViewModel)) {
-      Text(viewModel.name)
-    }
+    Text(viewModel.name)
   }
 }
 

--- a/StarWarsReader/FilmView/FilmVehicleRowView.swift
+++ b/StarWarsReader/FilmView/FilmVehicleRowView.swift
@@ -33,7 +33,7 @@ struct FilmVehicleRowView: View {
 // swiftlint:disable all
 struct FilmVehicleRowView_Previews: PreviewProvider {
   static let vm: FilmVehicleRowViewModel = {
-    let newHope = loadSampleFilm("newHope")
+    let newHope = loadSampleFilm(.newHope)
     return FilmVehicleRowViewModel(vehicle: newHope.vehicles.first!)
   }()
   

--- a/StarWarsReader/FilmView/FilmView.swift
+++ b/StarWarsReader/FilmView/FilmView.swift
@@ -214,7 +214,10 @@ extension FilmView {
 extension FilmView {
   static var mock: FilmView {
     let film = loadSampleFilm("newHope")
-    let viewModel = FilmViewModel(filmId: film.filmId)
+    let viewModel = FilmViewModel(
+      filmId: film.filmId,
+      characterViewInitializer: { _ in PersonView.mock }
+    )
     return FilmView(viewModel: viewModel)
   }
 }

--- a/StarWarsReader/FilmView/FilmView.swift
+++ b/StarWarsReader/FilmView/FilmView.swift
@@ -220,6 +220,7 @@ extension FilmView {
     let planetList: FilmPlanetListInitializer = { _ in FilmPlanetListView.mock }
     let speciesView: FilmSpeciesViewInitializer = { _ in SpeciesView.mock }
     let filmSpeciesList: FilmSpeciewsListInitializer = { _ in FilmSpeciesListView.mock }
+    let starshipView: FilmStarshipViewInitializer = { _ in StarshipView.mock }
     let viewModel = FilmViewModel(
       filmId: film.filmId,
       characterViewInitializer: characterView,
@@ -227,7 +228,8 @@ extension FilmView {
       planetView: planetView,
       filmPlanetList: planetList,
       speciesView: speciesView,
-      filmSpeciesList: filmSpeciesList
+      filmSpeciesList: filmSpeciesList,
+      starshipView: starshipView
     )
     return FilmView(viewModel: viewModel)
   }

--- a/StarWarsReader/FilmView/FilmView.swift
+++ b/StarWarsReader/FilmView/FilmView.swift
@@ -187,16 +187,16 @@ extension FilmView {
   var vehiclesSectionHeader: some View {
     HStack {
       Text(FilmViewSection.vehicles.title)
-      Spacer()
-//      if viewModel.needsDisclosure(forSection: FilmViewSection.vehicles) {
-//        NavigationLink(
-//          destination: FilmVehicleListView(viewModel: viewModel.vehicleListViewModel),
-//          tag: FilmViewSection.vehicles.destination.tag,
-//          selection: $navigationTag,
-//          label: {
-//            headerButton(forDestination: FilmViewSection.vehicles.destination)
-//        })
-//      }
+      if viewModel.needsDisclosure(forSection: FilmViewSection.vehicles) {
+        Spacer()
+        NavigationLink(
+          destination: viewModel.filmVehicleListView,
+          tag: FilmViewSection.vehicles.destination.tag,
+          selection: $navigationTag,
+          label: {
+            headerButton(forDestination: FilmViewSection.vehicles.destination)
+        })
+      }
     }
   }
 
@@ -223,6 +223,7 @@ extension FilmView {
     let starshipView: FilmStarshipViewInitializer = { _ in StarshipView.mock }
     let filmStarshipList: FilmStarshipListInitializer = { _ in FilmStarshipListView.mock }
     let vehicleView: FilmVehicleViewInitializer = { _ in VehicleView.mock }
+    let filmVehicleList: FilmVehicleListInitializer = { _ in FilmVehicleListView.mock }
     let viewModel = FilmViewModel(
       filmId: film.filmId,
       characterViewInitializer: characterView,
@@ -233,7 +234,8 @@ extension FilmView {
       filmSpeciesList: filmSpeciesList,
       starshipView: starshipView,
       filmStarshipList: filmStarshipList,
-      vehicleView: vehicleView
+      vehicleView: vehicleView,
+      filmVehicleList: filmVehicleList
     )
     return FilmView(viewModel: viewModel)
   }

--- a/StarWarsReader/FilmView/FilmView.swift
+++ b/StarWarsReader/FilmView/FilmView.swift
@@ -213,7 +213,7 @@ extension FilmView {
 
 extension FilmView {
   static var mock: FilmView {
-    let film = loadSampleFilm("newHope")
+    let film = loadSampleFilm(.newHope)
     let characterView: CharacterViewInitializer = { _ in PersonView.mock }
     let characterList: CharacterListInitializer = { _ in CharacterListView.mock }
     let planetView: FilmPlanetViewInitializer = { _ in PlanetView.mock }

--- a/StarWarsReader/FilmView/FilmView.swift
+++ b/StarWarsReader/FilmView/FilmView.swift
@@ -38,11 +38,13 @@ struct FilmView: View {
 extension FilmView {
   var topSection: some View {
     Section {
-      VStack(alignment: .leading, spacing: 12.0) {
-        Text("Episode \(viewModel.episode)")
-        Text(viewModel.title)
-          .font(.title)
-        Text("\"\(viewModel.crawlBeginning)\"")
+      NavigationLink(destination: viewModel.crawlLinkDestination!) {
+        VStack(alignment: .leading, spacing: 12.0) {
+          Text("Episode \(viewModel.episode)")
+          Text(viewModel.title)
+            .font(.title)
+          Text("\"\(viewModel.crawlBeginning)\"")
+        }
       }
     }
   }
@@ -224,6 +226,7 @@ extension FilmView {
     let filmStarshipList: FilmStarshipListInitializer = { _ in FilmStarshipListView.mock }
     let vehicleView: FilmVehicleViewInitializer = { _ in VehicleView.mock }
     let filmVehicleList: FilmVehicleListInitializer = { _ in FilmVehicleListView.mock }
+    let crawlView = FilmCrawlView(viewModel: FilmCrawlViewModel(film: loadSampleFilm(.newHope)))
     let viewModel = FilmViewModel(
       filmId: film.filmId,
       characterViewInitializer: characterView,
@@ -235,7 +238,8 @@ extension FilmView {
       starshipView: starshipView,
       filmStarshipList: filmStarshipList,
       vehicleView: vehicleView,
-      filmVehicleList: filmVehicleList
+      filmVehicleList: filmVehicleList,
+      crawlView: { _ in crawlView }
     )
     return FilmView(viewModel: viewModel)
   }

--- a/StarWarsReader/FilmView/FilmView.swift
+++ b/StarWarsReader/FilmView/FilmView.swift
@@ -222,6 +222,7 @@ extension FilmView {
     let filmSpeciesList: FilmSpeciewsListInitializer = { _ in FilmSpeciesListView.mock }
     let starshipView: FilmStarshipViewInitializer = { _ in StarshipView.mock }
     let filmStarshipList: FilmStarshipListInitializer = { _ in FilmStarshipListView.mock }
+    let vehicleView: FilmVehicleViewInitializer = { _ in VehicleView.mock }
     let viewModel = FilmViewModel(
       filmId: film.filmId,
       characterViewInitializer: characterView,
@@ -231,7 +232,8 @@ extension FilmView {
       speciesView: speciesView,
       filmSpeciesList: filmSpeciesList,
       starshipView: starshipView,
-      filmStarshipList: filmStarshipList
+      filmStarshipList: filmStarshipList,
+      vehicleView: vehicleView
     )
     return FilmView(viewModel: viewModel)
   }

--- a/StarWarsReader/FilmView/FilmView.swift
+++ b/StarWarsReader/FilmView/FilmView.swift
@@ -124,15 +124,15 @@ extension FilmView {
     HStack {
       Text(FilmViewSection.characters.title)
       Spacer()
-      if viewModel.needsDisclosure(forSection: FilmViewSection.characters) {
-        NavigationLink(
-          destination: CharacterListView(viewModel: viewModel.characterListViewModel),
-          tag: FilmViewSection.characters.destination.tag,
-          selection: $navigationTag,
-          label: {
-            headerButton(forDestination: FilmViewSection.characters.destination)
-        })
-      }
+//      if viewModel.needsDisclosure(forSection: FilmViewSection.characters) {
+//        NavigationLink(
+//          destination: CharacterListView(viewModel: viewModel.characterListViewModel),
+//          tag: FilmViewSection.characters.destination.tag,
+//          selection: $navigationTag,
+//          label: {
+//            headerButton(forDestination: FilmViewSection.characters.destination)
+//        })
+//      }
     }
   }
 
@@ -140,15 +140,15 @@ extension FilmView {
     HStack {
       Text(FilmViewSection.planets.title)
       Spacer()
-      if viewModel.needsDisclosure(forSection: FilmViewSection.planets) {
-        NavigationLink(
-          destination: FilmPlanetListView(viewModel: viewModel.planetListViewModel),
-          tag: FilmViewSection.planets.destination.tag,
-          selection: $navigationTag,
-          label: {
-            headerButton(forDestination: FilmViewSection.planets.destination)
-        })
-      }
+//      if viewModel.needsDisclosure(forSection: FilmViewSection.planets) {
+//        NavigationLink(
+//          destination: FilmPlanetListView(viewModel: viewModel.planetListViewModel),
+//          tag: FilmViewSection.planets.destination.tag,
+//          selection: $navigationTag,
+//          label: {
+//            headerButton(forDestination: FilmViewSection.planets.destination)
+//        })
+//      }
     }
   }
 
@@ -156,15 +156,15 @@ extension FilmView {
     HStack {
       Text(FilmViewSection.species.title)
       Spacer()
-      if viewModel.needsDisclosure(forSection: FilmViewSection.species) {
-        NavigationLink(
-          destination: FilmSpeciesListView(viewModel: viewModel.speciesListViewModel),
-          tag: FilmViewSection.species.destination.tag,
-          selection: $navigationTag,
-          label: {
-            headerButton(forDestination: FilmViewSection.species.destination)
-        })
-      }
+//      if viewModel.needsDisclosure(forSection: FilmViewSection.species) {
+//        NavigationLink(
+//          destination: FilmSpeciesListView(viewModel: viewModel.speciesListViewModel),
+//          tag: FilmViewSection.species.destination.tag,
+//          selection: $navigationTag,
+//          label: {
+//            headerButton(forDestination: FilmViewSection.species.destination)
+//        })
+//      }
     }
   }
 
@@ -172,15 +172,15 @@ extension FilmView {
     HStack {
       Text(FilmViewSection.starships.title)
       Spacer()
-      if viewModel.needsDisclosure(forSection: FilmViewSection.starships) {
-        NavigationLink(
-          destination: FilmStarshipListView(viewModel: viewModel.starshipListViewModel),
-          tag: FilmViewSection.starships.destination.tag,
-          selection: $navigationTag,
-          label: {
-            headerButton(forDestination: FilmViewSection.starships.destination)
-        })
-      }
+//      if viewModel.needsDisclosure(forSection: FilmViewSection.starships) {
+//        NavigationLink(
+//          destination: FilmStarshipListView(viewModel: viewModel.starshipListViewModel),
+//          tag: FilmViewSection.starships.destination.tag,
+//          selection: $navigationTag,
+//          label: {
+//            headerButton(forDestination: FilmViewSection.starships.destination)
+//        })
+//      }
     }
   }
 
@@ -188,15 +188,15 @@ extension FilmView {
     HStack {
       Text(FilmViewSection.vehicles.title)
       Spacer()
-      if viewModel.needsDisclosure(forSection: FilmViewSection.vehicles) {
-        NavigationLink(
-          destination: FilmVehicleListView(viewModel: viewModel.vehicleListViewModel),
-          tag: FilmViewSection.vehicles.destination.tag,
-          selection: $navigationTag,
-          label: {
-            headerButton(forDestination: FilmViewSection.vehicles.destination)
-        })
-      }
+//      if viewModel.needsDisclosure(forSection: FilmViewSection.vehicles) {
+//        NavigationLink(
+//          destination: FilmVehicleListView(viewModel: viewModel.vehicleListViewModel),
+//          tag: FilmViewSection.vehicles.destination.tag,
+//          selection: $navigationTag,
+//          label: {
+//            headerButton(forDestination: FilmViewSection.vehicles.destination)
+//        })
+//      }
     }
   }
 

--- a/StarWarsReader/FilmView/FilmView.swift
+++ b/StarWarsReader/FilmView/FilmView.swift
@@ -37,14 +37,12 @@ struct FilmView: View {
 
 extension FilmView {
   var topSection: some View {
-    NavigationLink(destination: FilmCrawlView(viewModel: FilmCrawlViewModel(film: viewModel.film!))) {
-      Section {
-        VStack(alignment: .leading, spacing: 12.0) {
-          Text("Episode \(viewModel.episode)")
-          Text(viewModel.title)
-            .font(.title)
-          Text("\"\(viewModel.crawlBeginning)\"")
-        }
+    Section {
+      VStack(alignment: .leading, spacing: 12.0) {
+        Text("Episode \(viewModel.episode)")
+        Text(viewModel.title)
+          .font(.title)
+        Text("\"\(viewModel.crawlBeginning)\"")
       }
     }
   }

--- a/StarWarsReader/FilmView/FilmView.swift
+++ b/StarWarsReader/FilmView/FilmView.swift
@@ -216,10 +216,12 @@ extension FilmView {
     let film = loadSampleFilm("newHope")
     let characterView: CharacterViewInitializer = { _ in PersonView.mock }
     let characterList: CharacterListInitializer = { _ in CharacterListView.mock }
+    let planetView: FilmPlanetViewInitializer = { _ in PlanetView.mock }
     let viewModel = FilmViewModel(
       filmId: film.filmId,
       characterViewInitializer: characterView,
-      characterList: characterList
+      characterList: characterList,
+      planetView: planetView
     )
     return FilmView(viewModel: viewModel)
   }

--- a/StarWarsReader/FilmView/FilmView.swift
+++ b/StarWarsReader/FilmView/FilmView.swift
@@ -211,16 +211,6 @@ extension FilmView {
 
 }
 
-struct HeaderButtonView: View {
-  var body: some View {
-    HStack {
-      Text("See all")
-      Image(systemName: "chevron.right")
-        .font(.caption)
-    }
-  }
-}
-
 extension FilmView {
   static var mock: FilmView {
     let film = loadSampleFilm("newHope")

--- a/StarWarsReader/FilmView/FilmView.swift
+++ b/StarWarsReader/FilmView/FilmView.swift
@@ -155,16 +155,16 @@ extension FilmView {
   var speciesSectionHeader: some View {
     HStack {
       Text(FilmViewSection.species.title)
-      Spacer()
-//      if viewModel.needsDisclosure(forSection: FilmViewSection.species) {
-//        NavigationLink(
-//          destination: FilmSpeciesListView(viewModel: viewModel.speciesListViewModel),
-//          tag: FilmViewSection.species.destination.tag,
-//          selection: $navigationTag,
-//          label: {
-//            headerButton(forDestination: FilmViewSection.species.destination)
-//        })
-//      }
+      if viewModel.needsDisclosure(forSection: FilmViewSection.species) {
+        Spacer()
+        NavigationLink(
+          destination: viewModel.filmSpeciesListView,
+          tag: FilmViewSection.species.destination.tag,
+          selection: $navigationTag,
+          label: {
+            headerButton(forDestination: FilmViewSection.species.destination)
+        })
+      }
     }
   }
 
@@ -219,13 +219,15 @@ extension FilmView {
     let planetView: FilmPlanetViewInitializer = { _ in PlanetView.mock }
     let planetList: FilmPlanetListInitializer = { _ in FilmPlanetListView.mock }
     let speciesView: FilmSpeciesViewInitializer = { _ in SpeciesView.mock }
+    let filmSpeciesList: FilmSpeciewsListInitializer = { _ in FilmSpeciesListView.mock }
     let viewModel = FilmViewModel(
       filmId: film.filmId,
       characterViewInitializer: characterView,
       characterList: characterList,
       planetView: planetView,
       filmPlanetList: planetList,
-      speciesView: speciesView
+      speciesView: speciesView,
+      filmSpeciesList: filmSpeciesList
     )
     return FilmView(viewModel: viewModel)
   }

--- a/StarWarsReader/FilmView/FilmView.swift
+++ b/StarWarsReader/FilmView/FilmView.swift
@@ -123,16 +123,16 @@ extension FilmView {
   var charactersSectionHeader: some View {
     HStack {
       Text(FilmViewSection.characters.title)
-      Spacer()
-//      if viewModel.needsDisclosure(forSection: FilmViewSection.characters) {
-//        NavigationLink(
-//          destination: CharacterListView(viewModel: viewModel.characterListViewModel),
-//          tag: FilmViewSection.characters.destination.tag,
-//          selection: $navigationTag,
-//          label: {
-//            headerButton(forDestination: FilmViewSection.characters.destination)
-//        })
-//      }
+      if viewModel.needsDisclosure(forSection: FilmViewSection.characters) {
+        Spacer()
+        NavigationLink(
+          destination: viewModel.characterListView,
+          tag: FilmViewSection.characters.destination.tag,
+          selection: $navigationTag,
+          label: {
+            headerButton(forDestination: FilmViewSection.characters.destination)
+        })
+      }
     }
   }
 
@@ -214,9 +214,12 @@ extension FilmView {
 extension FilmView {
   static var mock: FilmView {
     let film = loadSampleFilm("newHope")
+    let characterView: CharacterViewInitializer = { _ in PersonView.mock }
+    let characterList: CharacterListInitializer = { _ in CharacterListView.mock }
     let viewModel = FilmViewModel(
       filmId: film.filmId,
-      characterViewInitializer: { _ in PersonView.mock }
+      characterViewInitializer: characterView,
+      characterList: characterList
     )
     return FilmView(viewModel: viewModel)
   }

--- a/StarWarsReader/FilmView/FilmView.swift
+++ b/StarWarsReader/FilmView/FilmView.swift
@@ -139,16 +139,16 @@ extension FilmView {
   var planetsSectionHeader: some View {
     HStack {
       Text(FilmViewSection.planets.title)
-      Spacer()
-//      if viewModel.needsDisclosure(forSection: FilmViewSection.planets) {
-//        NavigationLink(
-//          destination: FilmPlanetListView(viewModel: viewModel.planetListViewModel),
-//          tag: FilmViewSection.planets.destination.tag,
-//          selection: $navigationTag,
-//          label: {
-//            headerButton(forDestination: FilmViewSection.planets.destination)
-//        })
-//      }
+      if viewModel.needsDisclosure(forSection: FilmViewSection.planets) {
+        Spacer()
+        NavigationLink(
+          destination: viewModel.filmPlanetsListView,
+          tag: FilmViewSection.planets.destination.tag,
+          selection: $navigationTag,
+          label: {
+            headerButton(forDestination: FilmViewSection.planets.destination)
+        })
+      }
     }
   }
 
@@ -217,11 +217,13 @@ extension FilmView {
     let characterView: CharacterViewInitializer = { _ in PersonView.mock }
     let characterList: CharacterListInitializer = { _ in CharacterListView.mock }
     let planetView: FilmPlanetViewInitializer = { _ in PlanetView.mock }
+    let planetList: FilmPlanetListInitializer = { _ in FilmPlanetListView.mock }
     let viewModel = FilmViewModel(
       filmId: film.filmId,
       characterViewInitializer: characterView,
       characterList: characterList,
-      planetView: planetView
+      planetView: planetView,
+      filmPlanetList: planetList
     )
     return FilmView(viewModel: viewModel)
   }

--- a/StarWarsReader/FilmView/FilmView.swift
+++ b/StarWarsReader/FilmView/FilmView.swift
@@ -221,17 +221,19 @@ struct HeaderButtonView: View {
   }
 }
 
-// swiftlint:disable type_name identifier_name
-struct FilmView_Previews: PreviewProvider {
-  static let vm: FilmViewModel = {
+extension FilmView {
+  static var mock: FilmView {
     let film = loadSampleFilm("newHope")
-    let service = MockDataService(film)
-    return FilmViewModel(filmId: film.filmId, dataService: service)
-  }()
+    let viewModel = FilmViewModel(filmId: film.filmId)
+    return FilmView(viewModel: viewModel)
+  }
+}
 
+// swiftlint:disable type_name
+struct FilmView_Previews: PreviewProvider {
   static var previews: some View {
     NavigationView {
-      FilmView(viewModel: vm)
+      FilmView.mock
     }
   }
 }

--- a/StarWarsReader/FilmView/FilmView.swift
+++ b/StarWarsReader/FilmView/FilmView.swift
@@ -171,16 +171,16 @@ extension FilmView {
   var starshipsSectionHeader: some View {
     HStack {
       Text(FilmViewSection.starships.title)
-      Spacer()
-//      if viewModel.needsDisclosure(forSection: FilmViewSection.starships) {
-//        NavigationLink(
-//          destination: FilmStarshipListView(viewModel: viewModel.starshipListViewModel),
-//          tag: FilmViewSection.starships.destination.tag,
-//          selection: $navigationTag,
-//          label: {
-//            headerButton(forDestination: FilmViewSection.starships.destination)
-//        })
-//      }
+      if viewModel.needsDisclosure(forSection: FilmViewSection.starships) {
+        Spacer()
+        NavigationLink(
+          destination: viewModel.filmStarshipListView,
+          tag: FilmViewSection.starships.destination.tag,
+          selection: $navigationTag,
+          label: {
+            headerButton(forDestination: FilmViewSection.starships.destination)
+        })
+      }
     }
   }
 
@@ -221,6 +221,7 @@ extension FilmView {
     let speciesView: FilmSpeciesViewInitializer = { _ in SpeciesView.mock }
     let filmSpeciesList: FilmSpeciewsListInitializer = { _ in FilmSpeciesListView.mock }
     let starshipView: FilmStarshipViewInitializer = { _ in StarshipView.mock }
+    let filmStarshipList: FilmStarshipListInitializer = { _ in FilmStarshipListView.mock }
     let viewModel = FilmViewModel(
       filmId: film.filmId,
       characterViewInitializer: characterView,
@@ -229,7 +230,8 @@ extension FilmView {
       filmPlanetList: planetList,
       speciesView: speciesView,
       filmSpeciesList: filmSpeciesList,
-      starshipView: starshipView
+      starshipView: starshipView,
+      filmStarshipList: filmStarshipList
     )
     return FilmView(viewModel: viewModel)
   }

--- a/StarWarsReader/FilmView/FilmView.swift
+++ b/StarWarsReader/FilmView/FilmView.swift
@@ -218,12 +218,14 @@ extension FilmView {
     let characterList: CharacterListInitializer = { _ in CharacterListView.mock }
     let planetView: FilmPlanetViewInitializer = { _ in PlanetView.mock }
     let planetList: FilmPlanetListInitializer = { _ in FilmPlanetListView.mock }
+    let speciesView: FilmSpeciesViewInitializer = { _ in SpeciesView.mock }
     let viewModel = FilmViewModel(
       filmId: film.filmId,
       characterViewInitializer: characterView,
       characterList: characterList,
       planetView: planetView,
-      filmPlanetList: planetList
+      filmPlanetList: planetList,
+      speciesView: speciesView
     )
     return FilmView(viewModel: viewModel)
   }

--- a/StarWarsReader/FilmView/FilmViewModel.swift
+++ b/StarWarsReader/FilmView/FilmViewModel.swift
@@ -66,6 +66,8 @@ final class FilmViewModel: ObservableObject {
 
   private let vehicleView: FilmVehicleViewInitializer
 
+  private let filmVehicleList: FilmVehicleListInitializer
+
   @Published var film: Film?
 
   var characters: [Film.Character] = []
@@ -89,6 +91,7 @@ final class FilmViewModel: ObservableObject {
     starshipView: @escaping FilmStarshipViewInitializer,
     filmStarshipList: @escaping FilmStarshipListInitializer,
     vehicleView: @escaping FilmVehicleViewInitializer,
+    filmVehicleList: @escaping FilmVehicleListInitializer,
     dataService: Swapi = SwapiService()
   ) {
     self.dataService = dataService
@@ -101,6 +104,7 @@ final class FilmViewModel: ObservableObject {
     self.starshipView = starshipView
     self.filmStarshipList = filmStarshipList
     self.vehicleView = vehicleView
+    self.filmVehicleList = filmVehicleList
     self.filmId = filmId
   }
 
@@ -262,7 +266,7 @@ final class FilmViewModel: ObservableObject {
     filmStarshipList(starships)
   }
 
-  var vehicleListViewModel: FilmVehicleListViewModel {
-    FilmVehicleListViewModel(vehicles: vehicles)
+  var filmVehicleListView: FilmVehicleListView {
+    filmVehicleList(vehicles)
   }
 }

--- a/StarWarsReader/FilmView/FilmViewModel.swift
+++ b/StarWarsReader/FilmView/FilmViewModel.swift
@@ -21,6 +21,10 @@ typealias FilmSpeciesViewInitializer = (Film.Species) -> SpeciesView
 
 typealias FilmSpeciewsListInitializer = ([Film.Species]) -> FilmSpeciesListView
 
+typealias FilmStarshipViewInitializer = (Film.Starship) -> StarshipView
+
+typealias FilmStarshipListInitializer = ([Film.Starship]) -> FilmStarshipListView
+
 final class FilmViewModel: ObservableObject {
 
   static let maximumSectionRows = 3
@@ -52,6 +56,8 @@ final class FilmViewModel: ObservableObject {
 
   private let filmSpeciesList: FilmSpeciewsListInitializer
 
+  private let starshipView: FilmStarshipViewInitializer
+
   @Published var film: Film?
 
   var characters: [Film.Character] = []
@@ -72,6 +78,7 @@ final class FilmViewModel: ObservableObject {
     filmPlanetList: @escaping FilmPlanetListInitializer,
     speciesView: @escaping FilmSpeciesViewInitializer,
     filmSpeciesList: @escaping FilmSpeciewsListInitializer,
+    starshipView: @escaping FilmStarshipViewInitializer,
     dataService: Swapi = SwapiService()
   ) {
     self.dataService = dataService
@@ -81,6 +88,7 @@ final class FilmViewModel: ObservableObject {
     self.filmPlanetList = filmPlanetList
     self.speciesView = speciesView
     self.filmSpeciesList = filmSpeciesList
+    self.starshipView = starshipView
     self.filmId = filmId
   }
 
@@ -184,7 +192,8 @@ final class FilmViewModel: ObservableObject {
   }
 
   func starshipViewModel(forStarshipAtIndex index: Int) -> FilmStarshipRowViewModel {
-    FilmStarshipRowViewModel(starship: starships(atIndex: index))
+    let aStarship = starships(atIndex: index)
+    return FilmStarshipRowViewModel(starship: aStarship, starshipView: starshipView(aStarship))
   }
 
   func vehicleViewModel(forVehicleAtIndex index: Int) -> FilmVehicleRowViewModel {

--- a/StarWarsReader/FilmView/FilmViewModel.swift
+++ b/StarWarsReader/FilmView/FilmViewModel.swift
@@ -17,6 +17,10 @@ typealias FilmPlanetViewInitializer = (Film.Planet) -> PlanetView
 
 typealias FilmPlanetListInitializer = ([Film.Planet]) -> FilmPlanetListView
 
+typealias FilmSpeciesViewInitializer = (Film.Species) -> SpeciesView
+
+typealias FilmSpeciewsListInitializer = ([Film.Species]) -> FilmSpeciesListView
+
 final class FilmViewModel: ObservableObject {
 
   static let maximumSectionRows = 3
@@ -44,6 +48,8 @@ final class FilmViewModel: ObservableObject {
 
   private let filmPlanetList: FilmPlanetListInitializer
 
+  private let speciesView: FilmSpeciesViewInitializer
+
   @Published var film: Film?
 
   var characters: [Film.Character] = []
@@ -62,6 +68,7 @@ final class FilmViewModel: ObservableObject {
     characterList: @escaping CharacterListInitializer,
     planetView: @escaping FilmPlanetViewInitializer,
     filmPlanetList: @escaping FilmPlanetListInitializer,
+    speciesView: @escaping FilmSpeciesViewInitializer,
     dataService: Swapi = SwapiService()
   ) {
     self.dataService = dataService
@@ -69,6 +76,7 @@ final class FilmViewModel: ObservableObject {
     self.characterList = characterList
     self.planetView = planetView
     self.filmPlanetList = filmPlanetList
+    self.speciesView = speciesView
     self.filmId = filmId
   }
 
@@ -167,7 +175,8 @@ final class FilmViewModel: ObservableObject {
   }
 
   func speciesViewModel(forSpeciesAtIndex index: Int) -> FilmSpeciesRowViewModel {
-    FilmSpeciesRowViewModel(species: species(atIndex: index))
+    let aSpecies = species(atIndex: index)
+    return FilmSpeciesRowViewModel(species: aSpecies, speciesView: speciesView(aSpecies))
   }
 
   func starshipViewModel(forStarshipAtIndex index: Int) -> FilmStarshipRowViewModel {

--- a/StarWarsReader/FilmView/FilmViewModel.swift
+++ b/StarWarsReader/FilmView/FilmViewModel.swift
@@ -11,6 +11,8 @@ import Combine
 
 typealias CharacterViewInitializer = (Film.Character) -> PersonView
 
+typealias CharacterListInitializer = ([Film.Character]) -> CharacterListView
+
 final class FilmViewModel: ObservableObject {
 
   static let maximumSectionRows = 3
@@ -32,6 +34,8 @@ final class FilmViewModel: ObservableObject {
 
   private let characterViewInitializer: CharacterViewInitializer
 
+  private let characterList: CharacterListInitializer
+
   @Published var film: Film?
 
   var characters: [Film.Character] = []
@@ -47,10 +51,12 @@ final class FilmViewModel: ObservableObject {
   init(
     filmId: String,
     characterViewInitializer: @escaping CharacterViewInitializer,
+    characterList: @escaping CharacterListInitializer,
     dataService: Swapi = SwapiService()
   ) {
     self.dataService = dataService
     self.characterViewInitializer = characterViewInitializer
+    self.characterList = characterList
     self.filmId = filmId
   }
 
@@ -187,6 +193,10 @@ final class FilmViewModel: ObservableObject {
     }
 
     return min(FilmViewModel.maximumSectionRows, allRows)
+  }
+
+  var characterListView: CharacterListView {
+    characterList(characters)
   }
 
   var characterListViewModel: CharacterListViewModel {

--- a/StarWarsReader/FilmView/FilmViewModel.swift
+++ b/StarWarsReader/FilmView/FilmViewModel.swift
@@ -25,6 +25,10 @@ typealias FilmStarshipViewInitializer = (Film.Starship) -> StarshipView
 
 typealias FilmStarshipListInitializer = ([Film.Starship]) -> FilmStarshipListView
 
+typealias FilmVehicleViewInitializer = (Film.Vehicle) -> VehicleView
+
+typealias FilmVehicleListInitializer = ([Film.Vehicle]) -> FilmVehicleListView
+
 final class FilmViewModel: ObservableObject {
 
   static let maximumSectionRows = 3
@@ -60,6 +64,8 @@ final class FilmViewModel: ObservableObject {
 
   private let filmStarshipList: FilmStarshipListInitializer
 
+  private let vehicleView: FilmVehicleViewInitializer
+
   @Published var film: Film?
 
   var characters: [Film.Character] = []
@@ -82,6 +88,7 @@ final class FilmViewModel: ObservableObject {
     filmSpeciesList: @escaping FilmSpeciewsListInitializer,
     starshipView: @escaping FilmStarshipViewInitializer,
     filmStarshipList: @escaping FilmStarshipListInitializer,
+    vehicleView: @escaping FilmVehicleViewInitializer,
     dataService: Swapi = SwapiService()
   ) {
     self.dataService = dataService
@@ -93,6 +100,7 @@ final class FilmViewModel: ObservableObject {
     self.filmSpeciesList = filmSpeciesList
     self.starshipView = starshipView
     self.filmStarshipList = filmStarshipList
+    self.vehicleView = vehicleView
     self.filmId = filmId
   }
 
@@ -201,7 +209,8 @@ final class FilmViewModel: ObservableObject {
   }
 
   func vehicleViewModel(forVehicleAtIndex index: Int) -> FilmVehicleRowViewModel {
-    FilmVehicleRowViewModel(vehicle: vehicle(atIndex: index))
+    let aVehicle = vehicle(atIndex: index)
+    return FilmVehicleRowViewModel(vehicle: aVehicle, vehicleView: vehicleView(aVehicle))
   }
 
   func needsDisclosure(forSection section: FilmViewSection) -> Bool {

--- a/StarWarsReader/FilmView/FilmViewModel.swift
+++ b/StarWarsReader/FilmView/FilmViewModel.swift
@@ -13,6 +13,8 @@ typealias CharacterViewInitializer = (Film.Character) -> PersonView
 
 typealias CharacterListInitializer = ([Film.Character]) -> CharacterListView
 
+typealias FilmPlanetViewInitializer = (Film.Planet) -> PlanetView
+
 final class FilmViewModel: ObservableObject {
 
   static let maximumSectionRows = 3
@@ -36,6 +38,8 @@ final class FilmViewModel: ObservableObject {
 
   private let characterList: CharacterListInitializer
 
+  private let planetView: FilmPlanetViewInitializer
+
   @Published var film: Film?
 
   var characters: [Film.Character] = []
@@ -52,11 +56,13 @@ final class FilmViewModel: ObservableObject {
     filmId: String,
     characterViewInitializer: @escaping CharacterViewInitializer,
     characterList: @escaping CharacterListInitializer,
+    planetView: @escaping FilmPlanetViewInitializer,
     dataService: Swapi = SwapiService()
   ) {
     self.dataService = dataService
     self.characterViewInitializer = characterViewInitializer
     self.characterList = characterList
+    self.planetView = planetView
     self.filmId = filmId
   }
 
@@ -147,7 +153,11 @@ final class FilmViewModel: ObservableObject {
   }
 
   func planetViewModel(forPlanetAtIndex index: Int) -> FilmPlanetRowViewModel {
-    FilmPlanetRowViewModel(planet: planet(atIndex: index))
+    let aPlanet = planet(atIndex: index)
+    return FilmPlanetRowViewModel(
+      planet: aPlanet,
+      planetView: planetView(aPlanet)
+    )
   }
 
   func speciesViewModel(forSpeciesAtIndex index: Int) -> FilmSpeciesRowViewModel {

--- a/StarWarsReader/FilmView/FilmViewModel.swift
+++ b/StarWarsReader/FilmView/FilmViewModel.swift
@@ -50,6 +50,8 @@ final class FilmViewModel: ObservableObject {
 
   private let speciesView: FilmSpeciesViewInitializer
 
+  private let filmSpeciesList: FilmSpeciewsListInitializer
+
   @Published var film: Film?
 
   var characters: [Film.Character] = []
@@ -69,6 +71,7 @@ final class FilmViewModel: ObservableObject {
     planetView: @escaping FilmPlanetViewInitializer,
     filmPlanetList: @escaping FilmPlanetListInitializer,
     speciesView: @escaping FilmSpeciesViewInitializer,
+    filmSpeciesList: @escaping FilmSpeciewsListInitializer,
     dataService: Swapi = SwapiService()
   ) {
     self.dataService = dataService
@@ -77,6 +80,7 @@ final class FilmViewModel: ObservableObject {
     self.planetView = planetView
     self.filmPlanetList = filmPlanetList
     self.speciesView = speciesView
+    self.filmSpeciesList = filmSpeciesList
     self.filmId = filmId
   }
 
@@ -228,8 +232,8 @@ final class FilmViewModel: ObservableObject {
     filmPlanetList(planets)
   }
 
-  var speciesListViewModel: FilmSpeciesListViewModel {
-    FilmSpeciesListViewModel(species: species)
+  var filmSpeciesListView: FilmSpeciesListView {
+    filmSpeciesList(species)
   }
 
   var starshipListViewModel: FilmStarshipListViewModel {

--- a/StarWarsReader/FilmView/FilmViewModel.swift
+++ b/StarWarsReader/FilmView/FilmViewModel.swift
@@ -58,6 +58,8 @@ final class FilmViewModel: ObservableObject {
 
   private let starshipView: FilmStarshipViewInitializer
 
+  private let filmStarshipList: FilmStarshipListInitializer
+
   @Published var film: Film?
 
   var characters: [Film.Character] = []
@@ -79,6 +81,7 @@ final class FilmViewModel: ObservableObject {
     speciesView: @escaping FilmSpeciesViewInitializer,
     filmSpeciesList: @escaping FilmSpeciewsListInitializer,
     starshipView: @escaping FilmStarshipViewInitializer,
+    filmStarshipList: @escaping FilmStarshipListInitializer,
     dataService: Swapi = SwapiService()
   ) {
     self.dataService = dataService
@@ -89,6 +92,7 @@ final class FilmViewModel: ObservableObject {
     self.speciesView = speciesView
     self.filmSpeciesList = filmSpeciesList
     self.starshipView = starshipView
+    self.filmStarshipList = filmStarshipList
     self.filmId = filmId
   }
 
@@ -245,8 +249,8 @@ final class FilmViewModel: ObservableObject {
     filmSpeciesList(species)
   }
 
-  var starshipListViewModel: FilmStarshipListViewModel {
-    FilmStarshipListViewModel(starships: starships)
+  var filmStarshipListView: FilmStarshipListView {
+    filmStarshipList(starships)
   }
 
   var vehicleListViewModel: FilmVehicleListViewModel {

--- a/StarWarsReader/FilmView/FilmViewModel.swift
+++ b/StarWarsReader/FilmView/FilmViewModel.swift
@@ -9,6 +9,8 @@
 import Foundation
 import Combine
 
+typealias CharacterViewInitializer = (Film.Character) -> PersonView
+
 final class FilmViewModel: ObservableObject {
 
   static let maximumSectionRows = 3
@@ -28,6 +30,8 @@ final class FilmViewModel: ObservableObject {
 
   private var needsFilmContent = true
 
+  private let characterViewInitializer: CharacterViewInitializer
+
   @Published var film: Film?
 
   var characters: [Film.Character] = []
@@ -42,9 +46,11 @@ final class FilmViewModel: ObservableObject {
 
   init(
     filmId: String,
+    characterViewInitializer: @escaping CharacterViewInitializer,
     dataService: Swapi = SwapiService()
   ) {
     self.dataService = dataService
+    self.characterViewInitializer = characterViewInitializer
     self.filmId = filmId
   }
 
@@ -127,7 +133,11 @@ final class FilmViewModel: ObservableObject {
   }
 
   func characterViewModel(forCharacterAtIndex index: Int) -> CharacterRowViewModel {
-    CharacterRowViewModel(character: character(atIndex: index))
+    let theCharacter = character(atIndex: index)
+    return CharacterRowViewModel(
+      character: theCharacter,
+      personView: characterViewInitializer(theCharacter)
+    )
   }
 
   func planetViewModel(forPlanetAtIndex index: Int) -> FilmPlanetRowViewModel {
@@ -180,7 +190,7 @@ final class FilmViewModel: ObservableObject {
   }
 
   var characterListViewModel: CharacterListViewModel {
-    CharacterListViewModel(characters: characters)
+    CharacterListViewModel(characters: characters, characterViewInitializer: characterViewInitializer)
   }
 
   var planetListViewModel: FilmPlanetListViewModel {

--- a/StarWarsReader/FilmView/FilmViewModel.swift
+++ b/StarWarsReader/FilmView/FilmViewModel.swift
@@ -29,6 +29,8 @@ typealias FilmVehicleViewInitializer = (Film.Vehicle) -> VehicleView
 
 typealias FilmVehicleListInitializer = ([Film.Vehicle]) -> FilmVehicleListView
 
+typealias CrawlView = (Film?) -> FilmCrawlView?
+
 final class FilmViewModel: ObservableObject {
 
   static let maximumSectionRows = 3
@@ -68,6 +70,8 @@ final class FilmViewModel: ObservableObject {
 
   private let filmVehicleList: FilmVehicleListInitializer
 
+  private let crawlView: CrawlView
+
   @Published var film: Film?
 
   var characters: [Film.Character] = []
@@ -92,6 +96,7 @@ final class FilmViewModel: ObservableObject {
     filmStarshipList: @escaping FilmStarshipListInitializer,
     vehicleView: @escaping FilmVehicleViewInitializer,
     filmVehicleList: @escaping FilmVehicleListInitializer,
+    crawlView: @escaping CrawlView,
     dataService: Swapi = SwapiService()
   ) {
     self.dataService = dataService
@@ -105,6 +110,7 @@ final class FilmViewModel: ObservableObject {
     self.filmStarshipList = filmStarshipList
     self.vehicleView = vehicleView
     self.filmVehicleList = filmVehicleList
+    self.crawlView = crawlView
     self.filmId = filmId
   }
 
@@ -184,6 +190,10 @@ final class FilmViewModel: ObservableObject {
 
   func vehicle(atIndex index: Int) -> Film.Vehicle {
     vehicles[index]
+  }
+
+  var crawlLinkDestination: FilmCrawlView? {
+    crawlView(film)
   }
 
   func characterViewModel(forCharacterAtIndex index: Int) -> CharacterRowViewModel {

--- a/StarWarsReader/FilmView/FilmViewModel.swift
+++ b/StarWarsReader/FilmView/FilmViewModel.swift
@@ -15,6 +15,8 @@ typealias CharacterListInitializer = ([Film.Character]) -> CharacterListView
 
 typealias FilmPlanetViewInitializer = (Film.Planet) -> PlanetView
 
+typealias FilmPlanetListInitializer = ([Film.Planet]) -> FilmPlanetListView
+
 final class FilmViewModel: ObservableObject {
 
   static let maximumSectionRows = 3
@@ -40,6 +42,8 @@ final class FilmViewModel: ObservableObject {
 
   private let planetView: FilmPlanetViewInitializer
 
+  private let filmPlanetList: FilmPlanetListInitializer
+
   @Published var film: Film?
 
   var characters: [Film.Character] = []
@@ -57,12 +61,14 @@ final class FilmViewModel: ObservableObject {
     characterViewInitializer: @escaping CharacterViewInitializer,
     characterList: @escaping CharacterListInitializer,
     planetView: @escaping FilmPlanetViewInitializer,
+    filmPlanetList: @escaping FilmPlanetListInitializer,
     dataService: Swapi = SwapiService()
   ) {
     self.dataService = dataService
     self.characterViewInitializer = characterViewInitializer
     self.characterList = characterList
     self.planetView = planetView
+    self.filmPlanetList = filmPlanetList
     self.filmId = filmId
   }
 
@@ -209,12 +215,8 @@ final class FilmViewModel: ObservableObject {
     characterList(characters)
   }
 
-  var characterListViewModel: CharacterListViewModel {
-    CharacterListViewModel(characters: characters, characterViewInitializer: characterViewInitializer)
-  }
-
-  var planetListViewModel: FilmPlanetListViewModel {
-    FilmPlanetListViewModel(planets: planets)
+  var filmPlanetsListView: FilmPlanetListView {
+    filmPlanetList(planets)
   }
 
   var speciesListViewModel: FilmSpeciesListViewModel {

--- a/StarWarsReader/FilmView/HeaderButton.swift
+++ b/StarWarsReader/FilmView/HeaderButton.swift
@@ -1,0 +1,20 @@
+//
+//  HeaderButton.swift
+//  StarWarsReader
+//
+//  Created by Joe Bramhall on 1/17/20.
+//  Copyright © 2020 thinx. All rights reserved.
+//
+
+import Foundation
+import SwiftUI
+
+struct HeaderButtonView: View {
+  var body: some View {
+    HStack {
+      Text("See all")
+      Image(systemName: "chevron.right")
+        .font(.caption)
+    }
+  }
+}

--- a/StarWarsReader/FilmsList/FilmRowView.swift
+++ b/StarWarsReader/FilmsList/FilmRowView.swift
@@ -14,10 +14,12 @@ struct FilmRowView: View {
 
   var body: some View {
     VStack(alignment: .leading, spacing: 6) {
-      Text("Episode \(viewModel.episode) (\(viewModel.released))")
-        .font(.body)
-      Text(viewModel.title)
-        .font(.largeTitle)
+      NavigationLink(destination: viewModel.filmView) {
+        Text("Episode \(viewModel.episode) (\(viewModel.released))")
+          .font(.body)
+        Text(viewModel.title)
+          .font(.largeTitle)
+      }
     }
   }
 }
@@ -26,7 +28,10 @@ extension FilmRowView {
 
   static var mock: FilmRowView {
     let film = sampleFilms[3]
-    let viewModel = FilmRowViewModel(film: film)
+    let viewModel = FilmRowViewModel(
+      film: film,
+      filmView: FilmView.mock
+    )
     return FilmRowView(viewModel: viewModel)
   }
 }

--- a/StarWarsReader/FilmsList/FilmRowView.swift
+++ b/StarWarsReader/FilmsList/FilmRowView.swift
@@ -13,8 +13,8 @@ struct FilmRowView: View {
   let viewModel: FilmRowViewModel
 
   var body: some View {
-    VStack(alignment: .leading, spacing: 6) {
-      NavigationLink(destination: viewModel.filmView) {
+    NavigationLink(destination: viewModel.filmView) {
+      VStack(alignment: .leading, spacing: 6) {
         Text("Episode \(viewModel.episode) (\(viewModel.released))")
           .font(.body)
         Text(viewModel.title)

--- a/StarWarsReader/FilmsList/FilmRowView.swift
+++ b/StarWarsReader/FilmsList/FilmRowView.swift
@@ -13,13 +13,11 @@ struct FilmRowView: View {
   let viewModel: FilmRowViewModel
 
   var body: some View {
-    NavigationLink(destination: FilmView(viewModel: viewModel.filmViewModel)) {
-      VStack(alignment: .leading, spacing: 6) {
-        Text("Episode \(viewModel.episode) (\(viewModel.released))")
-          .font(.body)
-        Text(viewModel.title)
-          .font(.largeTitle)
-      }
+    VStack(alignment: .leading, spacing: 6) {
+      Text("Episode \(viewModel.episode) (\(viewModel.released))")
+        .font(.body)
+      Text(viewModel.title)
+        .font(.largeTitle)
     }
   }
 }

--- a/StarWarsReader/FilmsList/FilmRowView.swift
+++ b/StarWarsReader/FilmsList/FilmRowView.swift
@@ -22,14 +22,18 @@ struct FilmRowView: View {
   }
 }
 
-// swiftlint:disable type_name identifier_name
-struct FilmRowView_Previews: PreviewProvider {
-  static let vm: FilmRowViewModel = {
-    let film = sampleFilms[3]
-    return FilmRowViewModel(film: film)
-  }()
+extension FilmRowView {
 
+  static var mock: FilmRowView {
+    let film = sampleFilms[3]
+    let viewModel = FilmRowViewModel(film: film)
+    return FilmRowView(viewModel: viewModel)
+  }
+}
+
+// swiftlint:disable type_name
+struct FilmRowView_Previews: PreviewProvider {
   static var previews: some View {
-    FilmRowView(viewModel: vm)
+    FilmRowView.mock
   }
 }

--- a/StarWarsReader/FilmsList/FilmRowViewModel.swift
+++ b/StarWarsReader/FilmsList/FilmRowViewModel.swift
@@ -36,8 +36,4 @@ struct FilmRowViewModel {
     return String(releaseYear)
   }
 
-  var filmViewModel: FilmViewModel {
-    FilmViewModel(filmId: film.filmId)
-  }
-
 }

--- a/StarWarsReader/FilmsList/FilmRowViewModel.swift
+++ b/StarWarsReader/FilmsList/FilmRowViewModel.swift
@@ -12,8 +12,14 @@ struct FilmRowViewModel {
 
   private let film: FilmsResponse.Film
 
-  init(film: FilmsResponse.Film) {
+  let filmView: FilmView
+
+  init(
+    film: FilmsResponse.Film,
+    filmView: FilmView
+  ) {
     self.film = film
+    self.filmView = filmView
   }
 
   var title: String {

--- a/StarWarsReader/FilmsList/FilmsListView.swift
+++ b/StarWarsReader/FilmsList/FilmsListView.swift
@@ -31,14 +31,22 @@ struct FilmsListView: View {
   }
 }
 
-// swiftlint:disable type_name identifier_name
-struct FilmsListView_Previews: PreviewProvider {
-  static let vm: FilmsListViewModel = {
-    let dataService = MockDataService(sampleFilms)
-    return FilmsListViewModel(dataService: dataService)
-  }()
+extension FilmsListView {
+  static var mock: FilmsListView {
+    let mockData = MockDataService(sampleFilms)
+    let viewModel = FilmsListViewModel(
+      filmViewInitializer: { _ in
+        FilmView.mock
+    },
+      dataService: mockData
+    )
+    return FilmsListView(viewModel: viewModel)
+  }
+}
 
+// swiftlint:disable type_name
+struct FilmsListView_Previews: PreviewProvider {
   static var previews: some View {
-    FilmsListView(viewModel: vm)
+    FilmsListView.mock
   }
 }

--- a/StarWarsReader/FilmsList/FilmsListViewModel.swift
+++ b/StarWarsReader/FilmsList/FilmsListViewModel.swift
@@ -9,6 +9,8 @@
 import Foundation
 import Combine
 
+typealias FilmViewInitializer = (FilmsResponse.Film) -> FilmView
+
 final class FilmsListViewModel: ObservableObject {
 
   private let dataService: Swapi
@@ -16,6 +18,10 @@ final class FilmsListViewModel: ObservableObject {
   private var disposables = Set<AnyCancellable>()
 
   private var needsFilms = true
+
+  private let filmViewInitializer: FilmViewInitializer = { _ in
+    FilmView.mock
+  }
 
   @Published var films: [FilmsResponse.Film] = []
 
@@ -43,7 +49,7 @@ final class FilmsListViewModel: ObservableObject {
   }
 
   func rowViewModel(forFilm film: FilmsResponse.Film) -> FilmRowViewModel {
-    return FilmRowViewModel(film: film)
+    return FilmRowViewModel(film: film, filmView: filmViewInitializer(film))
   }
 
 }

--- a/StarWarsReader/FilmsList/FilmsListViewModel.swift
+++ b/StarWarsReader/FilmsList/FilmsListViewModel.swift
@@ -19,13 +19,15 @@ final class FilmsListViewModel: ObservableObject {
 
   private var needsFilms = true
 
-  private let filmViewInitializer: FilmViewInitializer = { _ in
-    FilmView.mock
-  }
+  private let filmViewInitializer: FilmViewInitializer
 
   @Published var films: [FilmsResponse.Film] = []
 
-  init(dataService: Swapi = SwapiService()) {
+  init(
+    filmViewInitializer: @escaping FilmViewInitializer,
+    dataService: Swapi = SwapiService()
+  ) {
+    self.filmViewInitializer = filmViewInitializer
     self.dataService = dataService
   }
 

--- a/StarWarsReader/FlowCoordinator.swift
+++ b/StarWarsReader/FlowCoordinator.swift
@@ -19,9 +19,14 @@ struct FlowCoordinator {
   }
 
   private func makeFilmsList() -> FilmsListView {
-    let viewModel = FilmsListViewModel(filmViewInitializer: { _ in
-      FilmView.mock
+    let viewModel = FilmsListViewModel(filmViewInitializer: { film in
+      self.makeFilmView(with: film)
     })
     return FilmsListView(viewModel: viewModel)
+  }
+
+  private func makeFilmView(with film: FilmsResponse.Film) -> FilmView {
+    let viewModel = FilmViewModel(filmId: film.filmId)
+    return FilmView(viewModel: viewModel)
   }
 }

--- a/StarWarsReader/FlowCoordinator.swift
+++ b/StarWarsReader/FlowCoordinator.swift
@@ -57,9 +57,18 @@ struct FlowCoordinator {
       },
       filmVehicleList: { vehicles in
         self.makeVehicleListView(vehicles: vehicles)
-      }
-    )
+      },
+      crawlView: { film in
+        self.makeCrawlView(with: film)
+    })
+
     return FilmView(viewModel: viewModel)
+  }
+
+  private func makeCrawlView(with film: Film?) -> FilmCrawlView? {
+    guard let film = film else { return nil }
+    let viewModel = FilmCrawlViewModel(film: film)
+    return FilmCrawlView(viewModel: viewModel)
   }
 
   private func makeCharacterListView(characters: [Film.Character]) -> CharacterListView {

--- a/StarWarsReader/FlowCoordinator.swift
+++ b/StarWarsReader/FlowCoordinator.swift
@@ -45,6 +45,9 @@ struct FlowCoordinator {
       },
       filmSpeciesList: { species in
         self.makeSpeciesListView(species: species)
+      },
+      starshipView: { starship in
+        self.makeStarshipView(with: starship.starshipId)
       }
     )
     return FilmView(viewModel: viewModel)
@@ -92,5 +95,10 @@ struct FlowCoordinator {
   private func makeSpeciesView(with resourceId: String) -> SpeciesView {
     let viewModel = SpeciesViewModel(resourceId: resourceId)
     return SpeciesView(viewModel: viewModel)
+  }
+
+  private func makeStarshipView(with resourceId: String) -> StarshipView {
+    let viewModel = StarshipViewModel(resourceId: resourceId)
+    return StarshipView(viewModel: viewModel)
   }
 }

--- a/StarWarsReader/FlowCoordinator.swift
+++ b/StarWarsReader/FlowCoordinator.swift
@@ -30,9 +30,22 @@ struct FlowCoordinator {
       filmId: filmId,
       characterViewInitializer: { character in
         self.makePersonView(with: character.characterId)
-        }
-      )
+        },
+      characterList: { characters in
+        self.makeCharacterListView(characters: characters)
+      }
+    )
     return FilmView(viewModel: viewModel)
+  }
+
+  private func makeCharacterListView(characters: [Film.Character]) -> CharacterListView {
+    let viewModel = CharacterListViewModel(
+      characters: characters,
+      characterViewInitializer: { character in
+        self.makePersonView(with: character.characterId)
+      }
+    )
+    return CharacterListView(viewModel: viewModel)
   }
 
   private func makePersonView(with resourceId: String) -> PersonView {

--- a/StarWarsReader/FlowCoordinator.swift
+++ b/StarWarsReader/FlowCoordinator.swift
@@ -156,7 +156,11 @@ struct FlowCoordinator {
   }
 
   private func makeStarshipView(with resourceId: String) -> StarshipView {
-    let viewModel = StarshipViewModel(resourceId: resourceId)
+    let viewModel = StarshipViewModel(
+      resourceId: resourceId,
+      pilotView: { pilot in
+        self.makePersonView(with: pilot.pilotId)
+    })
     return StarshipView(viewModel: viewModel)
   }
 

--- a/StarWarsReader/FlowCoordinator.swift
+++ b/StarWarsReader/FlowCoordinator.swift
@@ -39,6 +39,9 @@ struct FlowCoordinator {
       },
       filmPlanetList: { planets in
         self.makePlanetsListView(planets: planets)
+      },
+      speciesView: { species in
+        self.makeSpeciesView(with: species.speciesId)
       }
     )
     return FilmView(viewModel: viewModel)
@@ -72,5 +75,10 @@ struct FlowCoordinator {
   private func makePlanetView(with resourceId: String) -> PlanetView {
     let viewModel = PlanetViewModel(planetId: resourceId)
     return PlanetView(viewModel: viewModel)
+  }
+
+  private func makeSpeciesView(with resourceId: String) -> SpeciesView {
+    let viewModel = SpeciesViewModel(resourceId: resourceId)
+    return SpeciesView(viewModel: viewModel)
   }
 }

--- a/StarWarsReader/FlowCoordinator.swift
+++ b/StarWarsReader/FlowCoordinator.swift
@@ -42,6 +42,9 @@ struct FlowCoordinator {
       },
       speciesView: { species in
         self.makeSpeciesView(with: species.speciesId)
+      },
+      filmSpeciesList: { species in
+        self.makeSpeciesListView(species: species)
       }
     )
     return FilmView(viewModel: viewModel)
@@ -65,6 +68,15 @@ struct FlowCoordinator {
       }
     )
     return FilmPlanetListView(viewModel: viewModel)
+  }
+
+  private func makeSpeciesListView(species: [Film.Species]) -> FilmSpeciesListView {
+    let viewModel = FilmSpeciesListViewModel(
+      species: species,
+      speciesView: { species in
+      self.makeSpeciesView(with: species.speciesId)
+    })
+    return FilmSpeciesListView(viewModel: viewModel)
   }
 
   private func makePersonView(with resourceId: String) -> PersonView {

--- a/StarWarsReader/FlowCoordinator.swift
+++ b/StarWarsReader/FlowCoordinator.swift
@@ -48,6 +48,9 @@ struct FlowCoordinator {
       },
       starshipView: { starship in
         self.makeStarshipView(with: starship.starshipId)
+      },
+      filmStarshipList: { starships in
+        self.makeStarshipListView(starships: starships)
       }
     )
     return FilmView(viewModel: viewModel)
@@ -80,6 +83,15 @@ struct FlowCoordinator {
       self.makeSpeciesView(with: species.speciesId)
     })
     return FilmSpeciesListView(viewModel: viewModel)
+  }
+
+  private func makeStarshipListView(starships: [Film.Starship]) -> FilmStarshipListView {
+    let viewModel = FilmStarshipListViewModel(
+      starships: starships,
+      filmStarshipView: { starship in
+        self.makeStarshipView(with: starship.starshipId)
+    })
+    return FilmStarshipListView(viewModel: viewModel)
   }
 
   private func makePersonView(with resourceId: String) -> PersonView {

--- a/StarWarsReader/FlowCoordinator.swift
+++ b/StarWarsReader/FlowCoordinator.swift
@@ -148,6 +148,9 @@ struct FlowCoordinator {
       resourceId: resourceId,
       filmView: { film in
         self.makeFilmView(with: film.filmId)
+      },
+      personView: { person in
+        self.makePersonView(with: person.personId)
     })
     return SpeciesView(viewModel: viewModel)
   }

--- a/StarWarsReader/FlowCoordinator.swift
+++ b/StarWarsReader/FlowCoordinator.swift
@@ -54,6 +54,9 @@ struct FlowCoordinator {
       },
       vehicleView: { vehicle in
         self.makeVehicleView(with: vehicle.vehicleId)
+      },
+      filmVehicleList: { vehicles in
+        self.makeVehicleListView(vehicles: vehicles)
       }
     )
     return FilmView(viewModel: viewModel)
@@ -95,6 +98,15 @@ struct FlowCoordinator {
         self.makeStarshipView(with: starship.starshipId)
     })
     return FilmStarshipListView(viewModel: viewModel)
+  }
+
+  private func makeVehicleListView(vehicles: [Film.Vehicle]) -> FilmVehicleListView {
+    let viewModel = FilmVehicleListViewModel(
+      vehicles: vehicles,
+      vehicleView: { vehicle in
+        self.makeVehicleView(with: vehicle.vehicleId)
+    })
+    return FilmVehicleListView(viewModel: viewModel)
   }
 
   private func makePersonView(with resourceId: String) -> PersonView {

--- a/StarWarsReader/FlowCoordinator.swift
+++ b/StarWarsReader/FlowCoordinator.swift
@@ -7,3 +7,21 @@
 //
 
 import Foundation
+import UIKit
+import SwiftUI
+
+struct FlowCoordinator {
+
+  func makeKeyAndVisible(_ window: UIWindow) {
+    let filmsList = makeFilmsList()
+    window.rootViewController = UIHostingController(rootView: filmsList)
+    window.makeKeyAndVisible()
+  }
+
+  private func makeFilmsList() -> FilmsListView {
+    let viewModel = FilmsListViewModel(filmViewInitializer: { _ in
+      FilmView.mock
+    })
+    return FilmsListView(viewModel: viewModel)
+  }
+}

--- a/StarWarsReader/FlowCoordinator.swift
+++ b/StarWarsReader/FlowCoordinator.swift
@@ -51,6 +51,9 @@ struct FlowCoordinator {
       },
       filmStarshipList: { starships in
         self.makeStarshipListView(starships: starships)
+      },
+      vehicleView: { vehicle in
+        self.makeVehicleView(with: vehicle.vehicleId)
       }
     )
     return FilmView(viewModel: viewModel)
@@ -112,5 +115,10 @@ struct FlowCoordinator {
   private func makeStarshipView(with resourceId: String) -> StarshipView {
     let viewModel = StarshipViewModel(resourceId: resourceId)
     return StarshipView(viewModel: viewModel)
+  }
+
+  private func makeVehicleView(with resourceId: String) -> VehicleView {
+    let viewModel = VehicleViewModel(resourceId: resourceId)
+    return VehicleView(viewModel: viewModel)
   }
 }

--- a/StarWarsReader/FlowCoordinator.swift
+++ b/StarWarsReader/FlowCoordinator.swift
@@ -110,7 +110,12 @@ struct FlowCoordinator {
   }
 
   private func makePersonView(with resourceId: String) -> PersonView {
-    let viewModel = PersonViewModel(resourceId: resourceId)
+    let viewModel = PersonViewModel(
+      resourceId: resourceId,
+      homeworldView: { planet in
+        guard let planet = planet else { return nil }
+        return self.makePlanetView(with: planet.planetId)
+    })
     return PersonView(viewModel: viewModel)
   }
 

--- a/StarWarsReader/FlowCoordinator.swift
+++ b/StarWarsReader/FlowCoordinator.swift
@@ -124,6 +124,9 @@ struct FlowCoordinator {
       },
       starshipView: { starship in
         self.makeStarshipView(with: starship.starshipId)
+      },
+      vehicleView: { vehicle in
+        self.makeVehicleView(with: vehicle.vehicleId)
     })
     return PersonView(viewModel: viewModel)
   }

--- a/StarWarsReader/FlowCoordinator.swift
+++ b/StarWarsReader/FlowCoordinator.swift
@@ -1,0 +1,9 @@
+//
+//  FlowCoordinator.swift
+//  StarWarsReader
+//
+//  Created by Joe Bramhall on 1/16/20.
+//  Copyright © 2020 thinx. All rights reserved.
+//
+
+import Foundation

--- a/StarWarsReader/FlowCoordinator.swift
+++ b/StarWarsReader/FlowCoordinator.swift
@@ -136,6 +136,9 @@ struct FlowCoordinator {
       planetId: resourceId,
       planetFilmView: { film in
         self.makeFilmView(with: film.filmId)
+      },
+      residentView: { resident in
+        self.makePersonView(with: resident.residentId)
     })
     return PlanetView(viewModel: viewModel)
   }

--- a/StarWarsReader/FlowCoordinator.swift
+++ b/StarWarsReader/FlowCoordinator.swift
@@ -132,7 +132,11 @@ struct FlowCoordinator {
   }
 
   private func makePlanetView(with resourceId: String) -> PlanetView {
-    let viewModel = PlanetViewModel(planetId: resourceId)
+    let viewModel = PlanetViewModel(
+      planetId: resourceId,
+      planetFilmView: { film in
+        self.makeFilmView(with: film.filmId)
+    })
     return PlanetView(viewModel: viewModel)
   }
 

--- a/StarWarsReader/FlowCoordinator.swift
+++ b/StarWarsReader/FlowCoordinator.swift
@@ -118,6 +118,9 @@ struct FlowCoordinator {
       },
       speciesView: { species in
         self.makeSpeciesView(with: species.speciesId)
+      },
+      filmView: { film in
+        self.makeFilmView(with: film.filmId)
     })
     return PersonView(viewModel: viewModel)
   }

--- a/StarWarsReader/FlowCoordinator.swift
+++ b/StarWarsReader/FlowCoordinator.swift
@@ -121,6 +121,9 @@ struct FlowCoordinator {
       },
       filmView: { film in
         self.makeFilmView(with: film.filmId)
+      },
+      starshipView: { starship in
+        self.makeStarshipView(with: starship.starshipId)
     })
     return PersonView(viewModel: viewModel)
   }

--- a/StarWarsReader/FlowCoordinator.swift
+++ b/StarWarsReader/FlowCoordinator.swift
@@ -144,7 +144,11 @@ struct FlowCoordinator {
   }
 
   private func makeSpeciesView(with resourceId: String) -> SpeciesView {
-    let viewModel = SpeciesViewModel(resourceId: resourceId)
+    let viewModel = SpeciesViewModel(
+      resourceId: resourceId,
+      filmView: { film in
+        self.makeFilmView(with: film.filmId)
+    })
     return SpeciesView(viewModel: viewModel)
   }
 

--- a/StarWarsReader/FlowCoordinator.swift
+++ b/StarWarsReader/FlowCoordinator.swift
@@ -168,7 +168,14 @@ struct FlowCoordinator {
   }
 
   private func makeVehicleView(with resourceId: String) -> VehicleView {
-    let viewModel = VehicleViewModel(resourceId: resourceId)
+    let viewModel = VehicleViewModel(
+      resourceId: resourceId,
+      filmView: { film in
+        self.makeFilmView(with: film.filmId)
+      },
+      pilotView: { pilot in
+        self.makePersonView(with: pilot.pilotId)
+    })
     return VehicleView(viewModel: viewModel)
   }
 }

--- a/StarWarsReader/FlowCoordinator.swift
+++ b/StarWarsReader/FlowCoordinator.swift
@@ -33,6 +33,9 @@ struct FlowCoordinator {
         },
       characterList: { characters in
         self.makeCharacterListView(characters: characters)
+      },
+      planetView: { planet in
+        self.makePlanetView(with: planet.planetId)
       }
     )
     return FilmView(viewModel: viewModel)
@@ -51,5 +54,10 @@ struct FlowCoordinator {
   private func makePersonView(with resourceId: String) -> PersonView {
     let viewModel = PersonViewModel(resourceId: resourceId)
     return PersonView(viewModel: viewModel)
+  }
+
+  private func makePlanetView(with resourceId: String) -> PlanetView {
+    let viewModel = PlanetViewModel(planetId: resourceId)
+    return PlanetView(viewModel: viewModel)
   }
 }

--- a/StarWarsReader/FlowCoordinator.swift
+++ b/StarWarsReader/FlowCoordinator.swift
@@ -160,6 +160,9 @@ struct FlowCoordinator {
       resourceId: resourceId,
       pilotView: { pilot in
         self.makePersonView(with: pilot.pilotId)
+      },
+      filmView: { film in
+        self.makeFilmView(with: film.filmId)
     })
     return StarshipView(viewModel: viewModel)
   }

--- a/StarWarsReader/FlowCoordinator.swift
+++ b/StarWarsReader/FlowCoordinator.swift
@@ -20,13 +20,23 @@ struct FlowCoordinator {
 
   private func makeFilmsList() -> FilmsListView {
     let viewModel = FilmsListViewModel(filmViewInitializer: { film in
-      self.makeFilmView(with: film)
+      self.makeFilmView(with: film.filmId)
     })
     return FilmsListView(viewModel: viewModel)
   }
 
-  private func makeFilmView(with film: FilmsResponse.Film) -> FilmView {
-    let viewModel = FilmViewModel(filmId: film.filmId)
+  private func makeFilmView(with filmId: String) -> FilmView {
+    let viewModel = FilmViewModel(
+      filmId: filmId,
+      characterViewInitializer: { character in
+        self.makePersonView(with: character.characterId)
+        }
+      )
     return FilmView(viewModel: viewModel)
+  }
+
+  private func makePersonView(with resourceId: String) -> PersonView {
+    let viewModel = PersonViewModel(resourceId: resourceId)
+    return PersonView(viewModel: viewModel)
   }
 }

--- a/StarWarsReader/FlowCoordinator.swift
+++ b/StarWarsReader/FlowCoordinator.swift
@@ -115,6 +115,9 @@ struct FlowCoordinator {
       homeworldView: { planet in
         guard let planet = planet else { return nil }
         return self.makePlanetView(with: planet.planetId)
+      },
+      speciesView: { species in
+        self.makeSpeciesView(with: species.speciesId)
     })
     return PersonView(viewModel: viewModel)
   }

--- a/StarWarsReader/FlowCoordinator.swift
+++ b/StarWarsReader/FlowCoordinator.swift
@@ -36,6 +36,9 @@ struct FlowCoordinator {
       },
       planetView: { planet in
         self.makePlanetView(with: planet.planetId)
+      },
+      filmPlanetList: { planets in
+        self.makePlanetsListView(planets: planets)
       }
     )
     return FilmView(viewModel: viewModel)
@@ -49,6 +52,16 @@ struct FlowCoordinator {
       }
     )
     return CharacterListView(viewModel: viewModel)
+  }
+
+  private func makePlanetsListView(planets: [Film.Planet]) -> FilmPlanetListView {
+    let viewModel = FilmPlanetListViewModel(
+      planets: planets,
+      planetView: { planet in
+        self.makePlanetView(with: planet.planetId)
+      }
+    )
+    return FilmPlanetListView(viewModel: viewModel)
   }
 
   private func makePersonView(with resourceId: String) -> PersonView {

--- a/StarWarsReader/PersonView/HomeworldRowView.swift
+++ b/StarWarsReader/PersonView/HomeworldRowView.swift
@@ -12,12 +12,10 @@ struct HomeworldRowViewModel {
 
   let homeworld: Person.Planet?
 
+  let planetView: PlanetView?
+
   var name: String {
     homeworld?.name ?? "n/a"
-  }
-
-  var planetViewModel: PlanetViewModel {
-    PlanetViewModel(planetId: homeworld!.planetId)
   }
 }
 
@@ -26,23 +24,28 @@ struct HomeworldRowView: View {
 
   var body: some View {
     Group {
-      if viewModel.homeworld == nil {
+      if viewModel.planetView == nil {
         Text(viewModel.name)
       } else {
-        Text(viewModel.name)
+        NavigationLink(destination: viewModel.planetView!) {
+          Text(viewModel.name)
+        }
       }
     }
   }
 }
 
-// swiftlint:disable type_name identifier_name
-struct HomeworldRowView_Previews: PreviewProvider {
-  static let vm: HomeworldRowViewModel = {
-    let luke = loadSamplePerson(.luke)
-    return HomeworldRowViewModel(homeworld: luke.homeworld!)
-  }()
+extension HomeworldRowView {
+  static var mock: HomeworldRowView {
+    let homeworld = loadSamplePerson(.luke).homeworld
+    let viewModel = HomeworldRowViewModel(homeworld: homeworld, planetView: PlanetView.mock)
+    return HomeworldRowView(viewModel: viewModel)
+  }
+}
 
+// swiftlint:disable type_name
+struct HomeworldRowView_Previews: PreviewProvider {
   static var previews: some View {
-    HomeworldRowView(viewModel: vm)
+    HomeworldRowView.mock
   }
 }

--- a/StarWarsReader/PersonView/HomeworldRowView.swift
+++ b/StarWarsReader/PersonView/HomeworldRowView.swift
@@ -38,7 +38,7 @@ struct HomeworldRowView: View {
 // swiftlint:disable type_name identifier_name
 struct HomeworldRowView_Previews: PreviewProvider {
   static let vm: HomeworldRowViewModel = {
-    let luke = loadSamplePerson("luke")
+    let luke = loadSamplePerson(.luke)
     return HomeworldRowViewModel(homeworld: luke.homeworld!)
   }()
 

--- a/StarWarsReader/PersonView/HomeworldRowView.swift
+++ b/StarWarsReader/PersonView/HomeworldRowView.swift
@@ -29,9 +29,7 @@ struct HomeworldRowView: View {
       if viewModel.homeworld == nil {
         Text(viewModel.name)
       } else {
-        NavigationLink(destination: PlanetView(viewModel: viewModel.planetViewModel)) {
-          Text(viewModel.name)
-        }
+        Text(viewModel.name)
       }
     }
   }

--- a/StarWarsReader/PersonView/PersonFilmRowView.swift
+++ b/StarWarsReader/PersonView/PersonFilmRowView.swift
@@ -22,7 +22,8 @@ struct PersonFilmRowViewModel {
       // TODO: factor out these mock initializers
       characterViewInitializer: { _ in PersonView.mock },
       characterList: { _ in CharacterListView.mock },
-      planetView: { _ in PlanetView.mock }
+      planetView: { _ in PlanetView.mock },
+      filmPlanetList: { _ in FilmPlanetListView.mock }
     )
   }
 }

--- a/StarWarsReader/PersonView/PersonFilmRowView.swift
+++ b/StarWarsReader/PersonView/PersonFilmRowView.swift
@@ -26,8 +26,9 @@ struct PersonFilmRowViewModel {
       filmPlanetList: { _ in FilmPlanetListView.mock },
       speciesView: { _ in SpeciesView.mock },
       filmSpeciesList: { _ in FilmSpeciesListView.mock },
-      starshipView: { _ in StarshipView.mock},
-      filmStarshipList: { _ in FilmStarshipListView.mock }
+      starshipView: { _ in StarshipView.mock },
+      filmStarshipList: { _ in FilmStarshipListView.mock },
+      vehicleView: { _ in VehicleView.mock }
     )
   }
 }

--- a/StarWarsReader/PersonView/PersonFilmRowView.swift
+++ b/StarWarsReader/PersonView/PersonFilmRowView.swift
@@ -17,7 +17,11 @@ struct PersonFilmRowViewModel {
   }
 
   var filmViewModel: FilmViewModel {
-    FilmViewModel(filmId: film.filmId)
+    FilmViewModel(
+      filmId: film.filmId,
+      // TODO: refactor mock initializer 
+      characterViewInitializer: { _ in PersonView.mock }
+    )
   }
 }
 

--- a/StarWarsReader/PersonView/PersonFilmRowView.swift
+++ b/StarWarsReader/PersonView/PersonFilmRowView.swift
@@ -28,7 +28,8 @@ struct PersonFilmRowViewModel {
       filmSpeciesList: { _ in FilmSpeciesListView.mock },
       starshipView: { _ in StarshipView.mock },
       filmStarshipList: { _ in FilmStarshipListView.mock },
-      vehicleView: { _ in VehicleView.mock }
+      vehicleView: { _ in VehicleView.mock },
+      filmVehicleList: { _ in FilmVehicleListView.mock }
     )
   }
 }

--- a/StarWarsReader/PersonView/PersonFilmRowView.swift
+++ b/StarWarsReader/PersonView/PersonFilmRowView.swift
@@ -24,7 +24,8 @@ struct PersonFilmRowViewModel {
       characterList: { _ in CharacterListView.mock },
       planetView: { _ in PlanetView.mock },
       filmPlanetList: { _ in FilmPlanetListView.mock },
-      speciesView: { _ in SpeciesView.mock }
+      speciesView: { _ in SpeciesView.mock },
+      filmSpeciesList: { _ in FilmSpeciesListView.mock }
     )
   }
 }

--- a/StarWarsReader/PersonView/PersonFilmRowView.swift
+++ b/StarWarsReader/PersonView/PersonFilmRowView.swift
@@ -42,7 +42,7 @@ struct PersonFilmRowView: View {
 // swiftlint:disable all
 struct PersonFilmRowView_Previews: PreviewProvider {
   static let vm: PersonFilmRowViewModel = {
-    let luke = loadSamplePerson("luke")
+    let luke = loadSamplePerson(.luke)
     return PersonFilmRowViewModel(film: luke.films.first!)
   }()
 

--- a/StarWarsReader/PersonView/PersonFilmRowView.swift
+++ b/StarWarsReader/PersonView/PersonFilmRowView.swift
@@ -26,9 +26,7 @@ struct PersonFilmRowView: View {
   let viewModel: PersonFilmRowViewModel
 
   var body: some View {
-    NavigationLink(destination: FilmView(viewModel: viewModel.filmViewModel, navigationTag: nil)) {
-      Text(viewModel.title)
-    }
+    Text(viewModel.title)
   }
 }
 

--- a/StarWarsReader/PersonView/PersonFilmRowView.swift
+++ b/StarWarsReader/PersonView/PersonFilmRowView.swift
@@ -12,25 +12,10 @@ struct PersonFilmRowViewModel {
 
   let film: Person.Film
 
+  let filmView: FilmView
+
   var title: String {
     film.title
-  }
-
-  var filmViewModel: FilmViewModel {
-    FilmViewModel(
-      filmId: film.filmId,
-      // TODO: factor out these mock initializers
-      characterViewInitializer: { _ in PersonView.mock },
-      characterList: { _ in CharacterListView.mock },
-      planetView: { _ in PlanetView.mock },
-      filmPlanetList: { _ in FilmPlanetListView.mock },
-      speciesView: { _ in SpeciesView.mock },
-      filmSpeciesList: { _ in FilmSpeciesListView.mock },
-      starshipView: { _ in StarshipView.mock },
-      filmStarshipList: { _ in FilmStarshipListView.mock },
-      vehicleView: { _ in VehicleView.mock },
-      filmVehicleList: { _ in FilmVehicleListView.mock }
-    )
   }
 }
 
@@ -39,18 +24,23 @@ struct PersonFilmRowView: View {
   let viewModel: PersonFilmRowViewModel
 
   var body: some View {
-    Text(viewModel.title)
+    NavigationLink(destination: viewModel.filmView) {
+      Text(viewModel.title)
+    }
+  }
+}
+
+extension PersonFilmRowView {
+  static var mock: PersonFilmRowView {
+    let personFilm = loadSamplePerson(.luke).films[0]
+    let viewModel = PersonFilmRowViewModel(film: personFilm, filmView: FilmView.mock)
+    return PersonFilmRowView(viewModel: viewModel)
   }
 }
 
 // swiftlint:disable all
 struct PersonFilmRowView_Previews: PreviewProvider {
-  static let vm: PersonFilmRowViewModel = {
-    let luke = loadSamplePerson(.luke)
-    return PersonFilmRowViewModel(film: luke.films.first!)
-  }()
-
   static var previews: some View {
-    PersonFilmRowView(viewModel: vm)
+    PersonFilmRowView.mock
   }
 }

--- a/StarWarsReader/PersonView/PersonFilmRowView.swift
+++ b/StarWarsReader/PersonView/PersonFilmRowView.swift
@@ -21,7 +21,8 @@ struct PersonFilmRowViewModel {
       filmId: film.filmId,
       // TODO: factor out these mock initializers
       characterViewInitializer: { _ in PersonView.mock },
-      characterList: { _ in CharacterListView.mock }
+      characterList: { _ in CharacterListView.mock },
+      planetView: { _ in PlanetView.mock }
     )
   }
 }

--- a/StarWarsReader/PersonView/PersonFilmRowView.swift
+++ b/StarWarsReader/PersonView/PersonFilmRowView.swift
@@ -25,7 +25,8 @@ struct PersonFilmRowViewModel {
       planetView: { _ in PlanetView.mock },
       filmPlanetList: { _ in FilmPlanetListView.mock },
       speciesView: { _ in SpeciesView.mock },
-      filmSpeciesList: { _ in FilmSpeciesListView.mock }
+      filmSpeciesList: { _ in FilmSpeciesListView.mock },
+      starshipView: { _ in StarshipView.mock}
     )
   }
 }

--- a/StarWarsReader/PersonView/PersonFilmRowView.swift
+++ b/StarWarsReader/PersonView/PersonFilmRowView.swift
@@ -26,7 +26,8 @@ struct PersonFilmRowViewModel {
       filmPlanetList: { _ in FilmPlanetListView.mock },
       speciesView: { _ in SpeciesView.mock },
       filmSpeciesList: { _ in FilmSpeciesListView.mock },
-      starshipView: { _ in StarshipView.mock}
+      starshipView: { _ in StarshipView.mock},
+      filmStarshipList: { _ in FilmStarshipListView.mock }
     )
   }
 }

--- a/StarWarsReader/PersonView/PersonFilmRowView.swift
+++ b/StarWarsReader/PersonView/PersonFilmRowView.swift
@@ -19,8 +19,9 @@ struct PersonFilmRowViewModel {
   var filmViewModel: FilmViewModel {
     FilmViewModel(
       filmId: film.filmId,
-      // TODO: refactor mock initializer 
-      characterViewInitializer: { _ in PersonView.mock }
+      // TODO: factor out these mock initializers
+      characterViewInitializer: { _ in PersonView.mock },
+      characterList: { _ in CharacterListView.mock }
     )
   }
 }

--- a/StarWarsReader/PersonView/PersonFilmRowView.swift
+++ b/StarWarsReader/PersonView/PersonFilmRowView.swift
@@ -23,7 +23,8 @@ struct PersonFilmRowViewModel {
       characterViewInitializer: { _ in PersonView.mock },
       characterList: { _ in CharacterListView.mock },
       planetView: { _ in PlanetView.mock },
-      filmPlanetList: { _ in FilmPlanetListView.mock }
+      filmPlanetList: { _ in FilmPlanetListView.mock },
+      speciesView: { _ in SpeciesView.mock }
     )
   }
 }

--- a/StarWarsReader/PersonView/PersonView.swift
+++ b/StarWarsReader/PersonView/PersonView.swift
@@ -130,6 +130,7 @@ extension PersonView {
       speciesView: { _ in SpeciesView.mock },
       filmView: { _ in FilmView.mock },
       starshipView: { _ in StarshipView.mock },
+      vehicleView: { _ in VehicleView.mock },
       dataService: mockData
     )
     return PersonView(viewModel: viewModel)

--- a/StarWarsReader/PersonView/PersonView.swift
+++ b/StarWarsReader/PersonView/PersonView.swift
@@ -126,6 +126,7 @@ extension PersonView {
     let mockData = MockDataService(luke)
     let viewModel = PersonViewModel(
       resourceId: luke.personId,
+      homeworldView: { _ in PlanetView.mock },
       dataService: mockData
     )
     return PersonView(viewModel: viewModel)

--- a/StarWarsReader/PersonView/PersonView.swift
+++ b/StarWarsReader/PersonView/PersonView.swift
@@ -120,17 +120,23 @@ extension PersonView {
 
 }
 
-// swiftlint:disable type_name identifier_name
-struct PersonView_Previews: PreviewProvider {
-  static let vm: PersonViewModel = {
-    let person = loadSamplePerson("luke")
-    let data = MockDataService(person)
-    return PersonViewModel(resourceId: person.personId, dataService: data)
-  }()
+extension PersonView {
+  static var mock: PersonView {
+    let luke = loadSamplePerson("luke")
+    let mockData = MockDataService(luke)
+    let viewModel = PersonViewModel(
+      resourceId: luke.personId,
+      dataService: mockData
+    )
+    return PersonView(viewModel: viewModel)
+  }
+}
 
+// swiftlint:disable type_name
+struct PersonView_Previews: PreviewProvider {
   static var previews: some View {
     NavigationView {
-      PersonView(viewModel: vm)
+      PersonView.mock
     }
   }
 }

--- a/StarWarsReader/PersonView/PersonView.swift
+++ b/StarWarsReader/PersonView/PersonView.swift
@@ -129,6 +129,7 @@ extension PersonView {
       homeworldView: { _ in PlanetView.mock },
       speciesView: { _ in SpeciesView.mock },
       filmView: { _ in FilmView.mock },
+      starshipView: { _ in StarshipView.mock },
       dataService: mockData
     )
     return PersonView(viewModel: viewModel)

--- a/StarWarsReader/PersonView/PersonView.swift
+++ b/StarWarsReader/PersonView/PersonView.swift
@@ -122,7 +122,7 @@ extension PersonView {
 
 extension PersonView {
   static var mock: PersonView {
-    let luke = loadSamplePerson("luke")
+    let luke = loadSamplePerson(.luke)
     let mockData = MockDataService(luke)
     let viewModel = PersonViewModel(
       resourceId: luke.personId,

--- a/StarWarsReader/PersonView/PersonView.swift
+++ b/StarWarsReader/PersonView/PersonView.swift
@@ -127,6 +127,7 @@ extension PersonView {
     let viewModel = PersonViewModel(
       resourceId: luke.personId,
       homeworldView: { _ in PlanetView.mock },
+      speciesView: { _ in SpeciesView.mock },
       dataService: mockData
     )
     return PersonView(viewModel: viewModel)

--- a/StarWarsReader/PersonView/PersonView.swift
+++ b/StarWarsReader/PersonView/PersonView.swift
@@ -128,6 +128,7 @@ extension PersonView {
       resourceId: luke.personId,
       homeworldView: { _ in PlanetView.mock },
       speciesView: { _ in SpeciesView.mock },
+      filmView: { _ in FilmView.mock },
       dataService: mockData
     )
     return PersonView(viewModel: viewModel)

--- a/StarWarsReader/PersonView/PersonViewModel.swift
+++ b/StarWarsReader/PersonView/PersonViewModel.swift
@@ -11,6 +11,8 @@ import Combine
 
 typealias PersonHomeworldView = (Person.Planet?) -> PlanetView?
 
+typealias PersonSpeciesView = (Person.Species) -> SpeciesView
+
 final class PersonViewModel: ObservableObject {
 
   private let personId: String
@@ -21,7 +23,9 @@ final class PersonViewModel: ObservableObject {
 
   private var needsPersonContent = true
 
-  private var homeworldView: PersonHomeworldView
+  private let homeworldView: PersonHomeworldView
+
+  private let speciesView: PersonSpeciesView
 
   @Published var person: Person?
 
@@ -36,10 +40,12 @@ final class PersonViewModel: ObservableObject {
   init(
     resourceId: String,
     homeworldView: @escaping PersonHomeworldView,
+    speciesView: @escaping PersonSpeciesView,
     dataService: Swapi = SwapiService()
   ) {
     personId = resourceId
     self.homeworldView = homeworldView
+    self.speciesView = speciesView
     self.dataService = dataService
   }
 
@@ -126,7 +132,7 @@ final class PersonViewModel: ObservableObject {
   }
 
   func speciesViewModel(forSpecies species: Person.Species) -> SpeciesRowViewModel {
-    SpeciesRowViewModel(species: species)
+    SpeciesRowViewModel(species: species, speciesView: speciesView(species))
   }
 
   func starshipViewModel(forStarship starship: Person.Starship) -> StarshipRowViewModel {

--- a/StarWarsReader/PersonView/PersonViewModel.swift
+++ b/StarWarsReader/PersonView/PersonViewModel.swift
@@ -15,6 +15,8 @@ typealias PersonSpeciesView = (Person.Species) -> SpeciesView
 
 typealias PersonFilmView = (Person.Film) -> FilmView
 
+typealias PersonStarshipView = (Person.Starship) -> StarshipView
+
 final class PersonViewModel: ObservableObject {
 
   private let personId: String
@@ -31,6 +33,8 @@ final class PersonViewModel: ObservableObject {
 
   private let filmView: PersonFilmView
 
+  private let starshipView: PersonStarshipView
+
   @Published var person: Person?
 
   var films: [Person.Film] = []
@@ -46,12 +50,14 @@ final class PersonViewModel: ObservableObject {
     homeworldView: @escaping PersonHomeworldView,
     speciesView: @escaping PersonSpeciesView,
     filmView: @escaping PersonFilmView,
+    starshipView: @escaping PersonStarshipView,
     dataService: Swapi = SwapiService()
   ) {
     personId = resourceId
     self.homeworldView = homeworldView
     self.speciesView = speciesView
     self.filmView = filmView
+    self.starshipView = starshipView
     self.dataService = dataService
   }
 
@@ -142,7 +148,7 @@ final class PersonViewModel: ObservableObject {
   }
 
   func starshipViewModel(forStarship starship: Person.Starship) -> StarshipRowViewModel {
-    StarshipRowViewModel(starship: starship)
+    StarshipRowViewModel(starship: starship, starshipView: starshipView(starship))
   }
 
   func vehicleViewModel(forVehicle vehicle: Person.Vehicle) -> VehicleRowViewModel {

--- a/StarWarsReader/PersonView/PersonViewModel.swift
+++ b/StarWarsReader/PersonView/PersonViewModel.swift
@@ -17,6 +17,8 @@ typealias PersonFilmView = (Person.Film) -> FilmView
 
 typealias PersonStarshipView = (Person.Starship) -> StarshipView
 
+typealias PersonVehicleView = (Person.Vehicle) -> VehicleView
+
 final class PersonViewModel: ObservableObject {
 
   private let personId: String
@@ -35,6 +37,8 @@ final class PersonViewModel: ObservableObject {
 
   private let starshipView: PersonStarshipView
 
+  private let vehicleView: PersonVehicleView
+
   @Published var person: Person?
 
   var films: [Person.Film] = []
@@ -51,6 +55,7 @@ final class PersonViewModel: ObservableObject {
     speciesView: @escaping PersonSpeciesView,
     filmView: @escaping PersonFilmView,
     starshipView: @escaping PersonStarshipView,
+    vehicleView: @escaping PersonVehicleView,
     dataService: Swapi = SwapiService()
   ) {
     personId = resourceId
@@ -58,6 +63,7 @@ final class PersonViewModel: ObservableObject {
     self.speciesView = speciesView
     self.filmView = filmView
     self.starshipView = starshipView
+    self.vehicleView = vehicleView
     self.dataService = dataService
   }
 
@@ -152,7 +158,7 @@ final class PersonViewModel: ObservableObject {
   }
 
   func vehicleViewModel(forVehicle vehicle: Person.Vehicle) -> VehicleRowViewModel {
-    VehicleRowViewModel(vehicle: vehicle)
+    VehicleRowViewModel(vehicle: vehicle, vehicleView: vehicleView(vehicle))
   }
 
   func filmViewModel(forFilm film: Person.Film) -> PersonFilmRowViewModel {

--- a/StarWarsReader/PersonView/PersonViewModel.swift
+++ b/StarWarsReader/PersonView/PersonViewModel.swift
@@ -13,6 +13,8 @@ typealias PersonHomeworldView = (Person.Planet?) -> PlanetView?
 
 typealias PersonSpeciesView = (Person.Species) -> SpeciesView
 
+typealias PersonFilmView = (Person.Film) -> FilmView
+
 final class PersonViewModel: ObservableObject {
 
   private let personId: String
@@ -26,6 +28,8 @@ final class PersonViewModel: ObservableObject {
   private let homeworldView: PersonHomeworldView
 
   private let speciesView: PersonSpeciesView
+
+  private let filmView: PersonFilmView
 
   @Published var person: Person?
 
@@ -41,11 +45,13 @@ final class PersonViewModel: ObservableObject {
     resourceId: String,
     homeworldView: @escaping PersonHomeworldView,
     speciesView: @escaping PersonSpeciesView,
+    filmView: @escaping PersonFilmView,
     dataService: Swapi = SwapiService()
   ) {
     personId = resourceId
     self.homeworldView = homeworldView
     self.speciesView = speciesView
+    self.filmView = filmView
     self.dataService = dataService
   }
 
@@ -144,6 +150,6 @@ final class PersonViewModel: ObservableObject {
   }
 
   func filmViewModel(forFilm film: Person.Film) -> PersonFilmRowViewModel {
-    PersonFilmRowViewModel(film: film)
+    PersonFilmRowViewModel(film: film, filmView: filmView(film))
   }
 }

--- a/StarWarsReader/PersonView/PersonViewModel.swift
+++ b/StarWarsReader/PersonView/PersonViewModel.swift
@@ -9,6 +9,8 @@
 import Foundation
 import Combine
 
+typealias PersonHomeworldView = (Person.Planet?) -> PlanetView?
+
 final class PersonViewModel: ObservableObject {
 
   private let personId: String
@@ -18,6 +20,8 @@ final class PersonViewModel: ObservableObject {
   private var disposables = Set<AnyCancellable>()
 
   private var needsPersonContent = true
+
+  private var homeworldView: PersonHomeworldView
 
   @Published var person: Person?
 
@@ -31,9 +35,11 @@ final class PersonViewModel: ObservableObject {
 
   init(
     resourceId: String,
+    homeworldView: @escaping PersonHomeworldView,
     dataService: Swapi = SwapiService()
   ) {
     personId = resourceId
+    self.homeworldView = homeworldView
     self.dataService = dataService
   }
 
@@ -116,7 +122,7 @@ final class PersonViewModel: ObservableObject {
   }
 
   var homeworldViewModel: HomeworldRowViewModel {
-    HomeworldRowViewModel(homeworld: person?.homeworld)
+    HomeworldRowViewModel(homeworld: person?.homeworld, planetView: homeworldView(person?.homeworld))
   }
 
   func speciesViewModel(forSpecies species: Person.Species) -> SpeciesRowViewModel {

--- a/StarWarsReader/PersonView/SpeciesRowView.swift
+++ b/StarWarsReader/PersonView/SpeciesRowView.swift
@@ -11,12 +11,10 @@ import SwiftUI
 struct SpeciesRowViewModel {
   let species: Person.Species
 
+  let speciesView: SpeciesView
+
   var name: String {
     species.name
-  }
-
-  var speciesViewModel: SpeciesViewModel {
-    SpeciesViewModel(resourceId: species.speciesId)
   }
 }
 
@@ -25,18 +23,23 @@ struct SpeciesRowView: View {
   let viewModel: SpeciesRowViewModel
 
   var body: some View {
-    Text(viewModel.name)
+    NavigationLink(destination: viewModel.speciesView) {
+      Text(viewModel.name)
+    }
+  }
+}
+
+extension SpeciesRowView {
+  static var mock: SpeciesRowView {
+    let personSpecies = loadSamplePerson(.luke).species[0]
+    let viewModel = SpeciesRowViewModel(species: personSpecies, speciesView: SpeciesView.mock)
+    return SpeciesRowView(viewModel: viewModel)
   }
 }
 
 // swiftlint:disable all
 struct SpeciesRowView_Previews: PreviewProvider {
-  static let vm: SpeciesRowViewModel = {
-    let luke = loadSamplePerson(.luke)
-    return SpeciesRowViewModel(species: luke.species.first!)
-  }()
-
   static var previews: some View {
-    SpeciesRowView(viewModel: vm)
+    SpeciesRowView.mock
   }
 }

--- a/StarWarsReader/PersonView/SpeciesRowView.swift
+++ b/StarWarsReader/PersonView/SpeciesRowView.swift
@@ -25,9 +25,7 @@ struct SpeciesRowView: View {
   let viewModel: SpeciesRowViewModel
 
   var body: some View {
-    NavigationLink(destination: SpeciesView(viewModel: viewModel.speciesViewModel)) {
-      Text(viewModel.name)
-    }
+    Text(viewModel.name)
   }
 }
 

--- a/StarWarsReader/PersonView/SpeciesRowView.swift
+++ b/StarWarsReader/PersonView/SpeciesRowView.swift
@@ -32,7 +32,7 @@ struct SpeciesRowView: View {
 // swiftlint:disable all
 struct SpeciesRowView_Previews: PreviewProvider {
   static let vm: SpeciesRowViewModel = {
-    let luke = loadSamplePerson("luke")
+    let luke = loadSamplePerson(.luke)
     return SpeciesRowViewModel(species: luke.species.first!)
   }()
 

--- a/StarWarsReader/PersonView/StarshipRowView.swift
+++ b/StarWarsReader/PersonView/StarshipRowView.swift
@@ -33,7 +33,7 @@ struct StarshipRowView: View {
 // swiftlint:disable all
 struct StarshipRowView_Previews: PreviewProvider {
   static let vm: StarshipRowViewModel = {
-    let luke = loadSamplePerson("luke")
+    let luke = loadSamplePerson(.luke)
     return StarshipRowViewModel(starship: luke.starships.first!)
   }()
 

--- a/StarWarsReader/PersonView/StarshipRowView.swift
+++ b/StarWarsReader/PersonView/StarshipRowView.swift
@@ -12,12 +12,10 @@ struct StarshipRowViewModel {
 
   let starship: Person.Starship
 
+  let starshipView: StarshipView
+
   var name: String {
     starship.name
-  }
-
-  var starshipViewModel: StarshipViewModel {
-    StarshipViewModel(resourceId: starship.starshipId)
   }
 }
 
@@ -26,18 +24,23 @@ struct StarshipRowView: View {
   let viewModel: StarshipRowViewModel
 
   var body: some View {
-    Text(viewModel.name)
+    NavigationLink(destination: viewModel.starshipView) {
+      Text(viewModel.name)
+    }
+  }
+}
+
+extension StarshipRowView {
+  static var mock: StarshipRowView {
+    let personStarship = loadSamplePerson(.luke).starships[0]
+    let viewModel = StarshipRowViewModel(starship: personStarship, starshipView: StarshipView.mock)
+    return StarshipRowView(viewModel: viewModel)
   }
 }
 
 // swiftlint:disable all
 struct StarshipRowView_Previews: PreviewProvider {
-  static let vm: StarshipRowViewModel = {
-    let luke = loadSamplePerson(.luke)
-    return StarshipRowViewModel(starship: luke.starships.first!)
-  }()
-
   static var previews: some View {
-    StarshipRowView(viewModel: vm)
+    StarshipRowView.mock
   }
 }

--- a/StarWarsReader/PersonView/StarshipRowView.swift
+++ b/StarWarsReader/PersonView/StarshipRowView.swift
@@ -26,9 +26,7 @@ struct StarshipRowView: View {
   let viewModel: StarshipRowViewModel
 
   var body: some View {
-    NavigationLink(destination: StarshipView(viewModel: viewModel.starshipViewModel)) {
-      Text(viewModel.name)
-    }
+    Text(viewModel.name)
   }
 }
 

--- a/StarWarsReader/PersonView/VehicleRowView.swift
+++ b/StarWarsReader/PersonView/VehicleRowView.swift
@@ -12,12 +12,10 @@ struct VehicleRowViewModel {
 
   let vehicle: Person.Vehicle
 
+  let vehicleView: VehicleView
+
   var name: String {
     vehicle.name
-  }
-
-  var vehicleViewModel: VehicleViewModel {
-    VehicleViewModel(resourceId: vehicle.vehicleId)
   }
 }
 
@@ -26,18 +24,23 @@ struct VehicleRowView: View {
   let viewModel: VehicleRowViewModel
 
   var body: some View {
-    Text(viewModel.name)
+    NavigationLink(destination: viewModel.vehicleView) {
+      Text(viewModel.name)
+    }
+  }
+}
+
+extension VehicleRowView {
+  static var mock: VehicleRowView {
+    let personVehicle = loadSamplePerson(.luke).vehicles[0]
+    let viewModel = VehicleRowViewModel(vehicle: personVehicle, vehicleView: VehicleView.mock)
+    return VehicleRowView(viewModel: viewModel)
   }
 }
 
 // swiftlint:disable all
 struct VehicleRowView_Previews: PreviewProvider {
-  static let vm: VehicleRowViewModel = {
-    let luke = loadSamplePerson(.luke)
-    return VehicleRowViewModel(vehicle: luke.vehicles.first!)
-  }()
-
   static var previews: some View {
-    VehicleRowView(viewModel: vm)
+    VehicleRowView.mock
   }
 }

--- a/StarWarsReader/PersonView/VehicleRowView.swift
+++ b/StarWarsReader/PersonView/VehicleRowView.swift
@@ -33,7 +33,7 @@ struct VehicleRowView: View {
 // swiftlint:disable all
 struct VehicleRowView_Previews: PreviewProvider {
   static let vm: VehicleRowViewModel = {
-    let luke = loadSamplePerson("luke")
+    let luke = loadSamplePerson(.luke)
     return VehicleRowViewModel(vehicle: luke.vehicles.first!)
   }()
 

--- a/StarWarsReader/PersonView/VehicleRowView.swift
+++ b/StarWarsReader/PersonView/VehicleRowView.swift
@@ -26,9 +26,7 @@ struct VehicleRowView: View {
   let viewModel: VehicleRowViewModel
 
   var body: some View {
-    NavigationLink(destination: VehicleView(viewModel: viewModel.vehicleViewModel)) {
-      Text(viewModel.name)
-    }
+    Text(viewModel.name)
   }
 }
 

--- a/StarWarsReader/PlanetView/PlanetFilmRowView.swift
+++ b/StarWarsReader/PlanetView/PlanetFilmRowView.swift
@@ -24,7 +24,8 @@ struct PlanetFilmRowViewModel {
       characterList: { _ in CharacterListView.mock },
       planetView: { _ in PlanetView.mock },
       filmPlanetList: { _ in FilmPlanetListView.mock },
-      speciesView: { _ in SpeciesView.mock }
+      speciesView: { _ in SpeciesView.mock },
+      filmSpeciesList: { _ in FilmSpeciesListView.mock }
     )
   }
 }

--- a/StarWarsReader/PlanetView/PlanetFilmRowView.swift
+++ b/StarWarsReader/PlanetView/PlanetFilmRowView.swift
@@ -21,7 +21,8 @@ struct PlanetFilmRowViewModel {
       filmId: film.filmId,
       // TODO: factor out these mock initializers
       characterViewInitializer: { _ in PersonView.mock },
-      characterList: { _ in CharacterListView.mock }
+      characterList: { _ in CharacterListView.mock },
+      planetView: { _ in PlanetView.mock }
     )
   }
 }

--- a/StarWarsReader/PlanetView/PlanetFilmRowView.swift
+++ b/StarWarsReader/PlanetView/PlanetFilmRowView.swift
@@ -26,7 +26,8 @@ struct PlanetFilmRowViewModel {
       filmPlanetList: { _ in FilmPlanetListView.mock },
       speciesView: { _ in SpeciesView.mock },
       filmSpeciesList: { _ in FilmSpeciesListView.mock },
-      starshipView: { _ in StarshipView.mock }
+      starshipView: { _ in StarshipView.mock },
+      filmStarshipList: { _ in FilmStarshipListView.mock }
     )
   }
 }

--- a/StarWarsReader/PlanetView/PlanetFilmRowView.swift
+++ b/StarWarsReader/PlanetView/PlanetFilmRowView.swift
@@ -23,7 +23,8 @@ struct PlanetFilmRowViewModel {
       characterViewInitializer: { _ in PersonView.mock },
       characterList: { _ in CharacterListView.mock },
       planetView: { _ in PlanetView.mock },
-      filmPlanetList: { _ in FilmPlanetListView.mock }
+      filmPlanetList: { _ in FilmPlanetListView.mock },
+      speciesView: { _ in SpeciesView.mock }
     )
   }
 }

--- a/StarWarsReader/PlanetView/PlanetFilmRowView.swift
+++ b/StarWarsReader/PlanetView/PlanetFilmRowView.swift
@@ -12,25 +12,10 @@ struct PlanetFilmRowViewModel {
 
   let film: Planet.Film
 
+  let filmView: FilmView
+
   var title: String {
     film.title
-  }
-
-  var filmViewModel: FilmViewModel {
-    FilmViewModel(
-      filmId: film.filmId,
-      // TODO: factor out these mock initializers
-      characterViewInitializer: { _ in PersonView.mock },
-      characterList: { _ in CharacterListView.mock },
-      planetView: { _ in PlanetView.mock },
-      filmPlanetList: { _ in FilmPlanetListView.mock },
-      speciesView: { _ in SpeciesView.mock },
-      filmSpeciesList: { _ in FilmSpeciesListView.mock },
-      starshipView: { _ in StarshipView.mock },
-      filmStarshipList: { _ in FilmStarshipListView.mock },
-      vehicleView: { _ in VehicleView.mock },
-      filmVehicleList: { _ in FilmVehicleListView.mock }
-    )
   }
 }
 
@@ -39,18 +24,23 @@ struct PlanetFilmRowView: View {
   let viewModel: PlanetFilmRowViewModel
 
   var body: some View {
-    Text(viewModel.title)
+    NavigationLink(destination: viewModel.filmView) {
+      Text(viewModel.title)
+    }
+  }
+}
+
+extension PlanetFilmRowView {
+  static var mock: PlanetFilmRowView {
+    let planetFilm = loadSamplePlanet(.tatooine).films[0]
+    let viewModel = PlanetFilmRowViewModel(film: planetFilm, filmView: FilmView.mock)
+    return PlanetFilmRowView(viewModel: viewModel)
   }
 }
 
 // swiftlint:disable all
 struct PlanetFilmRowView_Previews: PreviewProvider {
-  static let vm: PlanetFilmRowViewModel = {
-    let tatooine = loadSamplePlanet(.tatooine)
-    return PlanetFilmRowViewModel(film: tatooine.films.first!)
-  }()
-
   static var previews: some View {
-    PlanetFilmRowView(viewModel: vm)
+    PlanetFilmRowView.mock
   }
 }

--- a/StarWarsReader/PlanetView/PlanetFilmRowView.swift
+++ b/StarWarsReader/PlanetView/PlanetFilmRowView.swift
@@ -42,7 +42,7 @@ struct PlanetFilmRowView: View {
 // swiftlint:disable all
 struct PlanetFilmRowView_Previews: PreviewProvider {
   static let vm: PlanetFilmRowViewModel = {
-    let tatooine = loadSamplePlanet("tatooine")
+    let tatooine = loadSamplePlanet(.tatooine)
     return PlanetFilmRowViewModel(film: tatooine.films.first!)
   }()
 

--- a/StarWarsReader/PlanetView/PlanetFilmRowView.swift
+++ b/StarWarsReader/PlanetView/PlanetFilmRowView.swift
@@ -17,7 +17,11 @@ struct PlanetFilmRowViewModel {
   }
 
   var filmViewModel: FilmViewModel {
-    FilmViewModel(filmId: film.filmId)
+    FilmViewModel(
+      filmId: film.filmId,
+      // TODO: replace mock initializer
+      characterViewInitializer: { _ in PersonView.mock }
+    )
   }
 }
 

--- a/StarWarsReader/PlanetView/PlanetFilmRowView.swift
+++ b/StarWarsReader/PlanetView/PlanetFilmRowView.swift
@@ -26,9 +26,7 @@ struct PlanetFilmRowView: View {
   let viewModel: PlanetFilmRowViewModel
 
   var body: some View {
-    NavigationLink(destination: FilmView(viewModel: viewModel.filmViewModel, navigationTag: nil)) {
-      Text(viewModel.title)
-    }
+    Text(viewModel.title)
   }
 }
 

--- a/StarWarsReader/PlanetView/PlanetFilmRowView.swift
+++ b/StarWarsReader/PlanetView/PlanetFilmRowView.swift
@@ -27,7 +27,8 @@ struct PlanetFilmRowViewModel {
       speciesView: { _ in SpeciesView.mock },
       filmSpeciesList: { _ in FilmSpeciesListView.mock },
       starshipView: { _ in StarshipView.mock },
-      filmStarshipList: { _ in FilmStarshipListView.mock }
+      filmStarshipList: { _ in FilmStarshipListView.mock },
+      vehicleView: { _ in VehicleView.mock }
     )
   }
 }

--- a/StarWarsReader/PlanetView/PlanetFilmRowView.swift
+++ b/StarWarsReader/PlanetView/PlanetFilmRowView.swift
@@ -22,7 +22,8 @@ struct PlanetFilmRowViewModel {
       // TODO: factor out these mock initializers
       characterViewInitializer: { _ in PersonView.mock },
       characterList: { _ in CharacterListView.mock },
-      planetView: { _ in PlanetView.mock }
+      planetView: { _ in PlanetView.mock },
+      filmPlanetList: { _ in FilmPlanetListView.mock }
     )
   }
 }

--- a/StarWarsReader/PlanetView/PlanetFilmRowView.swift
+++ b/StarWarsReader/PlanetView/PlanetFilmRowView.swift
@@ -28,7 +28,8 @@ struct PlanetFilmRowViewModel {
       filmSpeciesList: { _ in FilmSpeciesListView.mock },
       starshipView: { _ in StarshipView.mock },
       filmStarshipList: { _ in FilmStarshipListView.mock },
-      vehicleView: { _ in VehicleView.mock }
+      vehicleView: { _ in VehicleView.mock },
+      filmVehicleList: { _ in FilmVehicleListView.mock }
     )
   }
 }

--- a/StarWarsReader/PlanetView/PlanetFilmRowView.swift
+++ b/StarWarsReader/PlanetView/PlanetFilmRowView.swift
@@ -19,8 +19,9 @@ struct PlanetFilmRowViewModel {
   var filmViewModel: FilmViewModel {
     FilmViewModel(
       filmId: film.filmId,
-      // TODO: replace mock initializer
-      characterViewInitializer: { _ in PersonView.mock }
+      // TODO: factor out these mock initializers
+      characterViewInitializer: { _ in PersonView.mock },
+      characterList: { _ in CharacterListView.mock }
     )
   }
 }

--- a/StarWarsReader/PlanetView/PlanetFilmRowView.swift
+++ b/StarWarsReader/PlanetView/PlanetFilmRowView.swift
@@ -25,7 +25,8 @@ struct PlanetFilmRowViewModel {
       planetView: { _ in PlanetView.mock },
       filmPlanetList: { _ in FilmPlanetListView.mock },
       speciesView: { _ in SpeciesView.mock },
-      filmSpeciesList: { _ in FilmSpeciesListView.mock }
+      filmSpeciesList: { _ in FilmSpeciesListView.mock },
+      starshipView: { _ in StarshipView.mock }
     )
   }
 }

--- a/StarWarsReader/PlanetView/PlanetView.swift
+++ b/StarWarsReader/PlanetView/PlanetView.swift
@@ -94,6 +94,7 @@ extension PlanetView {
     let mockData = MockDataService(tatooine)
     let viewModel = PlanetViewModel(
       planetId: tatooine.planetId,
+      planetFilmView: { _ in FilmView.mock },
       dataService: mockData
     )
     return PlanetView(viewModel: viewModel)

--- a/StarWarsReader/PlanetView/PlanetView.swift
+++ b/StarWarsReader/PlanetView/PlanetView.swift
@@ -88,20 +88,23 @@ extension PlanetView {
   }
 }
 
+extension PlanetView {
+  static var mock: PlanetView {
+    let tatooine = loadSamplePlanet("tatooine")
+    let mockData = MockDataService(tatooine)
+    let viewModel = PlanetViewModel(
+      planetId: tatooine.planetId,
+      dataService: mockData
+    )
+    return PlanetView(viewModel: viewModel)
+  }
+}
+
 // swiftlint:disable all
 struct PlanetView_Previews: PreviewProvider {
-  static let vm: PlanetViewModel = {
-    let tatooine = loadSamplePlanet("tatooine")
-    let dataService = MockDataService(tatooine)
-    return PlanetViewModel(
-      planetId: tatooine.planetId,
-      dataService: dataService
-    )
-  }()
-
   static var previews: some View {
     NavigationView {
-      PlanetView(viewModel: vm)
+      PlanetView.mock
     }
   }
 }

--- a/StarWarsReader/PlanetView/PlanetView.swift
+++ b/StarWarsReader/PlanetView/PlanetView.swift
@@ -90,7 +90,7 @@ extension PlanetView {
 
 extension PlanetView {
   static var mock: PlanetView {
-    let tatooine = loadSamplePlanet("tatooine")
+    let tatooine = loadSamplePlanet(.tatooine)
     let mockData = MockDataService(tatooine)
     let viewModel = PlanetViewModel(
       planetId: tatooine.planetId,

--- a/StarWarsReader/PlanetView/PlanetView.swift
+++ b/StarWarsReader/PlanetView/PlanetView.swift
@@ -95,6 +95,7 @@ extension PlanetView {
     let viewModel = PlanetViewModel(
       planetId: tatooine.planetId,
       planetFilmView: { _ in FilmView.mock },
+      residentView: { _ in PersonView.mock },
       dataService: mockData
     )
     return PlanetView(viewModel: viewModel)

--- a/StarWarsReader/PlanetView/PlanetViewModel.swift
+++ b/StarWarsReader/PlanetView/PlanetViewModel.swift
@@ -11,6 +11,8 @@ import Combine
 
 typealias PlanetFilmView = (Planet.Film) -> FilmView
 
+typealias ResidentView = (Planet.Resident) -> PersonView
+
 final class PlanetViewModel: ObservableObject {
 
   private let formatter: NumberFormatter = {
@@ -30,6 +32,8 @@ final class PlanetViewModel: ObservableObject {
 
   private let planetFilmView: PlanetFilmView
 
+  private let residentView: ResidentView
+
   @Published var planet: Planet?
 
   var residents: [Planet.Resident] = []
@@ -39,10 +43,12 @@ final class PlanetViewModel: ObservableObject {
   init(
     planetId: String,
     planetFilmView: @escaping PlanetFilmView,
+    residentView: @escaping ResidentView,
     dataService: Swapi = SwapiService()
   ) {
     self.planetId = planetId
     self.planetFilmView = planetFilmView
+    self.residentView = residentView
     self.dataService = dataService
   }
 
@@ -135,7 +141,7 @@ final class PlanetViewModel: ObservableObject {
   }
 
   func rowViewModel(forResident resident: Planet.Resident) -> ResidentRowViewModel {
-    ResidentRowViewModel(resident: resident)
+    ResidentRowViewModel(resident: resident, residentView: residentView(resident))
   }
 
 }

--- a/StarWarsReader/PlanetView/PlanetViewModel.swift
+++ b/StarWarsReader/PlanetView/PlanetViewModel.swift
@@ -9,6 +9,8 @@
 import Foundation
 import Combine
 
+typealias PlanetFilmView = (Planet.Film) -> FilmView
+
 final class PlanetViewModel: ObservableObject {
 
   private let formatter: NumberFormatter = {
@@ -26,6 +28,8 @@ final class PlanetViewModel: ObservableObject {
 
   private var needsPlanetContent = true
 
+  private let planetFilmView: PlanetFilmView
+
   @Published var planet: Planet?
 
   var residents: [Planet.Resident] = []
@@ -34,9 +38,11 @@ final class PlanetViewModel: ObservableObject {
 
   init(
     planetId: String,
+    planetFilmView: @escaping PlanetFilmView,
     dataService: Swapi = SwapiService()
   ) {
     self.planetId = planetId
+    self.planetFilmView = planetFilmView
     self.dataService = dataService
   }
 
@@ -125,7 +131,7 @@ final class PlanetViewModel: ObservableObject {
   }
 
   func rowViewModel(forFilm film: Planet.Film) -> PlanetFilmRowViewModel {
-    PlanetFilmRowViewModel(film: film)
+    PlanetFilmRowViewModel(film: film, filmView: planetFilmView(film))
   }
 
   func rowViewModel(forResident resident: Planet.Resident) -> ResidentRowViewModel {

--- a/StarWarsReader/PlanetView/ResidentRowView.swift
+++ b/StarWarsReader/PlanetView/ResidentRowView.swift
@@ -33,7 +33,7 @@ struct ResidentRowView: View {
 // swiftlint:disable all
 struct ResidentRowView_Previews: PreviewProvider {
   static let vm: ResidentRowViewModel = {
-    let tatooine = loadSamplePlanet("tatooine")
+    let tatooine = loadSamplePlanet(.tatooine)
     return ResidentRowViewModel(resident: tatooine.residents.first!)
   }()
 

--- a/StarWarsReader/PlanetView/ResidentRowView.swift
+++ b/StarWarsReader/PlanetView/ResidentRowView.swift
@@ -21,7 +21,8 @@ struct ResidentRowViewModel {
     PersonViewModel(
       resourceId: resident.residentId,
       homeworldView: { _ in PlanetView.mock },
-      speciesView: { _ in SpeciesView.mock }
+      speciesView: { _ in SpeciesView.mock },
+      filmView: { _ in FilmView.mock }
     )
   }
 }

--- a/StarWarsReader/PlanetView/ResidentRowView.swift
+++ b/StarWarsReader/PlanetView/ResidentRowView.swift
@@ -17,7 +17,8 @@ struct ResidentRowViewModel {
   }
 
   var personViewModel: PersonViewModel {
-    PersonViewModel(resourceId: resident.residentId)
+    // TODO: refactor mock value 
+    PersonViewModel(resourceId: resident.residentId, homeworldView: { _ in PlanetView.mock })
   }
 }
 

--- a/StarWarsReader/PlanetView/ResidentRowView.swift
+++ b/StarWarsReader/PlanetView/ResidentRowView.swift
@@ -12,20 +12,10 @@ struct ResidentRowViewModel {
 
   let resident: Planet.Resident
 
+  let residentView: PersonView
+
   var name: String {
     resident.name
-  }
-
-  var personViewModel: PersonViewModel {
-    // TODO: refactor mock value 
-    PersonViewModel(
-      resourceId: resident.residentId,
-      homeworldView: { _ in PlanetView.mock },
-      speciesView: { _ in SpeciesView.mock },
-      filmView: { _ in FilmView.mock },
-      starshipView: { _ in StarshipView.mock },
-      vehicleView: { _ in VehicleView.mock }
-    )
   }
 }
 
@@ -34,18 +24,23 @@ struct ResidentRowView: View {
   let viewModel: ResidentRowViewModel
 
   var body: some View {
-    Text(viewModel.name)
+    NavigationLink(destination: viewModel.residentView) {
+      Text(viewModel.name)
+    }
+  }
+}
+
+extension ResidentRowView {
+  static var mock: ResidentRowView {
+    let resident = loadSamplePlanet(.tatooine).residents[0]
+    let viewModel = ResidentRowViewModel(resident: resident, residentView: PersonView.mock)
+    return ResidentRowView(viewModel: viewModel)
   }
 }
 
 // swiftlint:disable all
 struct ResidentRowView_Previews: PreviewProvider {
-  static let vm: ResidentRowViewModel = {
-    let tatooine = loadSamplePlanet(.tatooine)
-    return ResidentRowViewModel(resident: tatooine.residents.first!)
-  }()
-
   static var previews: some View {
-    ResidentRowView(viewModel: vm)
+    ResidentRowView.mock
   }
 }

--- a/StarWarsReader/PlanetView/ResidentRowView.swift
+++ b/StarWarsReader/PlanetView/ResidentRowView.swift
@@ -26,9 +26,7 @@ struct ResidentRowView: View {
   let viewModel: ResidentRowViewModel
 
   var body: some View {
-    NavigationLink(destination: PersonView(viewModel: viewModel.personViewModel)) {
-      Text(viewModel.name)
-    }
+    Text(viewModel.name)
   }
 }
 

--- a/StarWarsReader/PlanetView/ResidentRowView.swift
+++ b/StarWarsReader/PlanetView/ResidentRowView.swift
@@ -18,7 +18,11 @@ struct ResidentRowViewModel {
 
   var personViewModel: PersonViewModel {
     // TODO: refactor mock value 
-    PersonViewModel(resourceId: resident.residentId, homeworldView: { _ in PlanetView.mock })
+    PersonViewModel(
+      resourceId: resident.residentId,
+      homeworldView: { _ in PlanetView.mock },
+      speciesView: { _ in SpeciesView.mock }
+    )
   }
 }
 

--- a/StarWarsReader/PlanetView/ResidentRowView.swift
+++ b/StarWarsReader/PlanetView/ResidentRowView.swift
@@ -23,7 +23,8 @@ struct ResidentRowViewModel {
       homeworldView: { _ in PlanetView.mock },
       speciesView: { _ in SpeciesView.mock },
       filmView: { _ in FilmView.mock },
-      starshipView: { _ in StarshipView.mock }
+      starshipView: { _ in StarshipView.mock },
+      vehicleView: { _ in VehicleView.mock }
     )
   }
 }

--- a/StarWarsReader/PlanetView/ResidentRowView.swift
+++ b/StarWarsReader/PlanetView/ResidentRowView.swift
@@ -22,7 +22,8 @@ struct ResidentRowViewModel {
       resourceId: resident.residentId,
       homeworldView: { _ in PlanetView.mock },
       speciesView: { _ in SpeciesView.mock },
-      filmView: { _ in FilmView.mock }
+      filmView: { _ in FilmView.mock },
+      starshipView: { _ in StarshipView.mock }
     )
   }
 }

--- a/StarWarsReader/SceneDelegate.swift
+++ b/StarWarsReader/SceneDelegate.swift
@@ -13,24 +13,18 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
   var window: UIWindow?
 
+  let flowCoordinator = FlowCoordinator()
+
   func scene(
     _ scene: UIScene,
     willConnectTo session: UISceneSession,
     options connectionOptions: UIScene.ConnectionOptions
   ) {
     // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
-    // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
-    // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
-
-    // Create the SwiftUI view that provides the window contents.
-    let contentView = FilmsListView(viewModel: FilmsListViewModel())
-
-    // Use a UIHostingController as window root view controller.
     if let windowScene = scene as? UIWindowScene {
         let window = UIWindow(windowScene: windowScene)
-        window.rootViewController = UIHostingController(rootView: contentView)
+        flowCoordinator.makeKeyAndVisible(window)
         self.window = window
-        window.makeKeyAndVisible()
     }
   }
 

--- a/StarWarsReader/SpeciesView/SpeciesFilmRowView.swift
+++ b/StarWarsReader/SpeciesView/SpeciesFilmRowView.swift
@@ -17,7 +17,11 @@ struct SpeciesFilmRowViewModel {
   }
 
   var filmViewModel: FilmViewModel {
-    FilmViewModel(filmId: film.filmId)
+    FilmViewModel(
+      filmId: film.filmId,
+      // TODO: replace mock initializer 
+      characterViewInitializer: { _ in PersonView.mock }
+    )
   }
 }
 

--- a/StarWarsReader/SpeciesView/SpeciesFilmRowView.swift
+++ b/StarWarsReader/SpeciesView/SpeciesFilmRowView.swift
@@ -42,7 +42,7 @@ struct SpeciesFilmRowView: View {
 // swiftlint:disable all
 struct SpeciesFilmRowView_Previews: PreviewProvider {
   static let vm: SpeciesFilmRowViewModel = {
-    let twilek = loadSampleSpecies("twilek")
+    let twilek = loadSampleSpecies(.twilek)
     return SpeciesFilmRowViewModel(film: twilek.films.first!)
   }()
 

--- a/StarWarsReader/SpeciesView/SpeciesFilmRowView.swift
+++ b/StarWarsReader/SpeciesView/SpeciesFilmRowView.swift
@@ -21,7 +21,8 @@ struct SpeciesFilmRowViewModel {
       filmId: film.filmId,
       // TODO: factor out these mock initializers
       characterViewInitializer: { _ in PersonView.mock },
-      characterList: { _ in CharacterListView.mock }
+      characterList: { _ in CharacterListView.mock },
+      planetView: { _ in PlanetView.mock }
     )
   }
 }

--- a/StarWarsReader/SpeciesView/SpeciesFilmRowView.swift
+++ b/StarWarsReader/SpeciesView/SpeciesFilmRowView.swift
@@ -26,9 +26,7 @@ struct SpeciesFilmRowView: View {
   let viewModel: SpeciesFilmRowViewModel
 
   var body: some View {
-    NavigationLink(destination: FilmView(viewModel: viewModel.filmViewModel, navigationTag: nil)) {
-      Text(viewModel.title)
-    }
+    Text(viewModel.title)
   }
 }
 

--- a/StarWarsReader/SpeciesView/SpeciesFilmRowView.swift
+++ b/StarWarsReader/SpeciesView/SpeciesFilmRowView.swift
@@ -12,25 +12,10 @@ struct SpeciesFilmRowViewModel {
 
   let film: Species.Film
 
+  let filmView: FilmView
+
   var title: String {
     film.title
-  }
-
-  var filmViewModel: FilmViewModel {
-    FilmViewModel(
-      filmId: film.filmId,
-      // TODO: factor out these mock initializers
-      characterViewInitializer: { _ in PersonView.mock },
-      characterList: { _ in CharacterListView.mock },
-      planetView: { _ in PlanetView.mock },
-      filmPlanetList: { _ in FilmPlanetListView.mock },
-      speciesView: { _ in SpeciesView.mock },
-      filmSpeciesList: { _ in FilmSpeciesListView.mock },
-      starshipView: { _ in StarshipView.mock },
-      filmStarshipList: { _ in FilmStarshipListView.mock },
-      vehicleView: { _ in VehicleView.mock },
-      filmVehicleList: { _ in FilmVehicleListView.mock }
-    )
   }
 }
 
@@ -39,18 +24,23 @@ struct SpeciesFilmRowView: View {
   let viewModel: SpeciesFilmRowViewModel
 
   var body: some View {
-    Text(viewModel.title)
+    NavigationLink(destination: viewModel.filmView) {
+      Text(viewModel.title)
+    }
+  }
+}
+
+extension SpeciesFilmRowView {
+  static var mock: SpeciesFilmRowView {
+    let speciesFilm = loadSampleSpecies(.twilek).films[0]
+    let viewModel = SpeciesFilmRowViewModel(film: speciesFilm, filmView: FilmView.mock)
+    return SpeciesFilmRowView(viewModel: viewModel)
   }
 }
 
 // swiftlint:disable all
 struct SpeciesFilmRowView_Previews: PreviewProvider {
-  static let vm: SpeciesFilmRowViewModel = {
-    let twilek = loadSampleSpecies(.twilek)
-    return SpeciesFilmRowViewModel(film: twilek.films.first!)
-  }()
-
   static var previews: some View {
-    SpeciesFilmRowView(viewModel: vm)
+    SpeciesFilmRowView.mock
   }
 }

--- a/StarWarsReader/SpeciesView/SpeciesFilmRowView.swift
+++ b/StarWarsReader/SpeciesView/SpeciesFilmRowView.swift
@@ -19,8 +19,9 @@ struct SpeciesFilmRowViewModel {
   var filmViewModel: FilmViewModel {
     FilmViewModel(
       filmId: film.filmId,
-      // TODO: replace mock initializer 
-      characterViewInitializer: { _ in PersonView.mock }
+      // TODO: factor out these mock initializers
+      characterViewInitializer: { _ in PersonView.mock },
+      characterList: { _ in CharacterListView.mock }
     )
   }
 }

--- a/StarWarsReader/SpeciesView/SpeciesFilmRowView.swift
+++ b/StarWarsReader/SpeciesView/SpeciesFilmRowView.swift
@@ -27,7 +27,8 @@ struct SpeciesFilmRowViewModel {
       speciesView: { _ in SpeciesView.mock },
       filmSpeciesList: { _ in FilmSpeciesListView.mock },
       starshipView: { _ in StarshipView.mock },
-      filmStarshipList: { _ in FilmStarshipListView.mock }
+      filmStarshipList: { _ in FilmStarshipListView.mock },
+      vehicleView: { _ in VehicleView.mock }
     )
   }
 }

--- a/StarWarsReader/SpeciesView/SpeciesFilmRowView.swift
+++ b/StarWarsReader/SpeciesView/SpeciesFilmRowView.swift
@@ -25,7 +25,8 @@ struct SpeciesFilmRowViewModel {
       planetView: { _ in PlanetView.mock },
       filmPlanetList: { _ in FilmPlanetListView.mock },
       speciesView: { _ in SpeciesView.mock },
-      filmSpeciesList: { _ in FilmSpeciesListView.mock }
+      filmSpeciesList: { _ in FilmSpeciesListView.mock },
+      starshipView: { _ in StarshipView.mock }
     )
   }
 }

--- a/StarWarsReader/SpeciesView/SpeciesFilmRowView.swift
+++ b/StarWarsReader/SpeciesView/SpeciesFilmRowView.swift
@@ -24,7 +24,8 @@ struct SpeciesFilmRowViewModel {
       characterList: { _ in CharacterListView.mock },
       planetView: { _ in PlanetView.mock },
       filmPlanetList: { _ in FilmPlanetListView.mock },
-      speciesView: { _ in SpeciesView.mock }
+      speciesView: { _ in SpeciesView.mock },
+      filmSpeciesList: { _ in FilmSpeciesListView.mock }
     )
   }
 }

--- a/StarWarsReader/SpeciesView/SpeciesFilmRowView.swift
+++ b/StarWarsReader/SpeciesView/SpeciesFilmRowView.swift
@@ -28,7 +28,8 @@ struct SpeciesFilmRowViewModel {
       filmSpeciesList: { _ in FilmSpeciesListView.mock },
       starshipView: { _ in StarshipView.mock },
       filmStarshipList: { _ in FilmStarshipListView.mock },
-      vehicleView: { _ in VehicleView.mock }
+      vehicleView: { _ in VehicleView.mock },
+      filmVehicleList: { _ in FilmVehicleListView.mock }
     )
   }
 }

--- a/StarWarsReader/SpeciesView/SpeciesFilmRowView.swift
+++ b/StarWarsReader/SpeciesView/SpeciesFilmRowView.swift
@@ -22,7 +22,8 @@ struct SpeciesFilmRowViewModel {
       // TODO: factor out these mock initializers
       characterViewInitializer: { _ in PersonView.mock },
       characterList: { _ in CharacterListView.mock },
-      planetView: { _ in PlanetView.mock }
+      planetView: { _ in PlanetView.mock },
+      filmPlanetList: { _ in FilmPlanetListView.mock }
     )
   }
 }

--- a/StarWarsReader/SpeciesView/SpeciesFilmRowView.swift
+++ b/StarWarsReader/SpeciesView/SpeciesFilmRowView.swift
@@ -26,7 +26,8 @@ struct SpeciesFilmRowViewModel {
       filmPlanetList: { _ in FilmPlanetListView.mock },
       speciesView: { _ in SpeciesView.mock },
       filmSpeciesList: { _ in FilmSpeciesListView.mock },
-      starshipView: { _ in StarshipView.mock }
+      starshipView: { _ in StarshipView.mock },
+      filmStarshipList: { _ in FilmStarshipListView.mock }
     )
   }
 }

--- a/StarWarsReader/SpeciesView/SpeciesFilmRowView.swift
+++ b/StarWarsReader/SpeciesView/SpeciesFilmRowView.swift
@@ -23,7 +23,8 @@ struct SpeciesFilmRowViewModel {
       characterViewInitializer: { _ in PersonView.mock },
       characterList: { _ in CharacterListView.mock },
       planetView: { _ in PlanetView.mock },
-      filmPlanetList: { _ in FilmPlanetListView.mock }
+      filmPlanetList: { _ in FilmPlanetListView.mock },
+      speciesView: { _ in SpeciesView.mock }
     )
   }
 }

--- a/StarWarsReader/SpeciesView/SpeciesPersonRowView.swift
+++ b/StarWarsReader/SpeciesView/SpeciesPersonRowView.swift
@@ -17,7 +17,8 @@ struct SpeciesPersonRowViewModel {
   }
 
   var personViewModel: PersonViewModel {
-    PersonViewModel(resourceId: person.personId)
+    // TODO: refactor mock value 
+    PersonViewModel(resourceId: person.personId, homeworldView: { _ in PlanetView.mock })
   }
 }
 

--- a/StarWarsReader/SpeciesView/SpeciesPersonRowView.swift
+++ b/StarWarsReader/SpeciesView/SpeciesPersonRowView.swift
@@ -18,7 +18,11 @@ struct SpeciesPersonRowViewModel {
 
   var personViewModel: PersonViewModel {
     // TODO: refactor mock value 
-    PersonViewModel(resourceId: person.personId, homeworldView: { _ in PlanetView.mock })
+    PersonViewModel(
+      resourceId: person.personId,
+      homeworldView: { _ in PlanetView.mock },
+      speciesView: { _ in SpeciesView.mock }
+    )
   }
 }
 

--- a/StarWarsReader/SpeciesView/SpeciesPersonRowView.swift
+++ b/StarWarsReader/SpeciesView/SpeciesPersonRowView.swift
@@ -23,7 +23,8 @@ struct SpeciesPersonRowViewModel {
       homeworldView: { _ in PlanetView.mock },
       speciesView: { _ in SpeciesView.mock },
       filmView: { _ in FilmView.mock },
-      starshipView: { _ in StarshipView.mock }
+      starshipView: { _ in StarshipView.mock },
+      vehicleView: { _ in VehicleView.mock }
     )
   }
 }

--- a/StarWarsReader/SpeciesView/SpeciesPersonRowView.swift
+++ b/StarWarsReader/SpeciesView/SpeciesPersonRowView.swift
@@ -21,7 +21,8 @@ struct SpeciesPersonRowViewModel {
     PersonViewModel(
       resourceId: person.personId,
       homeworldView: { _ in PlanetView.mock },
-      speciesView: { _ in SpeciesView.mock }
+      speciesView: { _ in SpeciesView.mock },
+      filmView: { _ in FilmView.mock }
     )
   }
 }

--- a/StarWarsReader/SpeciesView/SpeciesPersonRowView.swift
+++ b/StarWarsReader/SpeciesView/SpeciesPersonRowView.swift
@@ -22,7 +22,8 @@ struct SpeciesPersonRowViewModel {
       resourceId: person.personId,
       homeworldView: { _ in PlanetView.mock },
       speciesView: { _ in SpeciesView.mock },
-      filmView: { _ in FilmView.mock }
+      filmView: { _ in FilmView.mock },
+      starshipView: { _ in StarshipView.mock }
     )
   }
 }

--- a/StarWarsReader/SpeciesView/SpeciesPersonRowView.swift
+++ b/StarWarsReader/SpeciesView/SpeciesPersonRowView.swift
@@ -26,9 +26,7 @@ struct SpeciesPersonRowView: View {
   let viewModel: SpeciesPersonRowViewModel
 
   var body: some View {
-    NavigationLink(destination: PersonView(viewModel: viewModel.personViewModel)) {
-      Text(viewModel.name)
-    }
+    Text(viewModel.name)
   }
 }
 

--- a/StarWarsReader/SpeciesView/SpeciesPersonRowView.swift
+++ b/StarWarsReader/SpeciesView/SpeciesPersonRowView.swift
@@ -12,20 +12,10 @@ struct SpeciesPersonRowViewModel {
 
   let person: Species.Person
 
+  let personView: PersonView
+
   var name: String {
     person.name
-  }
-
-  var personViewModel: PersonViewModel {
-    // TODO: refactor mock value 
-    PersonViewModel(
-      resourceId: person.personId,
-      homeworldView: { _ in PlanetView.mock },
-      speciesView: { _ in SpeciesView.mock },
-      filmView: { _ in FilmView.mock },
-      starshipView: { _ in StarshipView.mock },
-      vehicleView: { _ in VehicleView.mock }
-    )
   }
 }
 
@@ -34,18 +24,23 @@ struct SpeciesPersonRowView: View {
   let viewModel: SpeciesPersonRowViewModel
 
   var body: some View {
-    Text(viewModel.name)
+    NavigationLink(destination: viewModel.personView) {
+      Text(viewModel.name)
+    }
+  }
+}
+
+extension SpeciesPersonRowView {
+  static var mock: SpeciesPersonRowView {
+    let speciesPerson = loadSampleSpecies(.twilek).people[0]
+    let viewModel = SpeciesPersonRowViewModel(person: speciesPerson, personView: PersonView.mock)
+    return SpeciesPersonRowView(viewModel: viewModel)
   }
 }
 
 // swiftlint:disable all
 struct SpeciesPersonRowView_Previews: PreviewProvider {
-  static let vm: SpeciesPersonRowViewModel = {
-    let twilek = loadSampleSpecies(.twilek)
-    return SpeciesPersonRowViewModel(person: twilek.people.first!)
-  }()
-
   static var previews: some View {
-    SpeciesPersonRowView(viewModel: vm)
+    SpeciesPersonRowView.mock
   }
 }

--- a/StarWarsReader/SpeciesView/SpeciesPersonRowView.swift
+++ b/StarWarsReader/SpeciesView/SpeciesPersonRowView.swift
@@ -33,7 +33,7 @@ struct SpeciesPersonRowView: View {
 // swiftlint:disable all
 struct SpeciesPersonRowView_Previews: PreviewProvider {
   static let vm: SpeciesPersonRowViewModel = {
-    let twilek = loadSampleSpecies("twilek")
+    let twilek = loadSampleSpecies(.twilek)
     return SpeciesPersonRowViewModel(person: twilek.people.first!)
   }()
 

--- a/StarWarsReader/SpeciesView/SpeciesView.swift
+++ b/StarWarsReader/SpeciesView/SpeciesView.swift
@@ -78,20 +78,23 @@ extension SpeciesView {
   }
 }
 
+extension SpeciesView {
+  static var mock: SpeciesView {
+    let twilek = loadSampleSpecies("twilek")
+    let mockData = MockDataService(twilek)
+    let viewModel = SpeciesViewModel(
+      resourceId: twilek.speciesId,
+      dataService: mockData
+    )
+    return SpeciesView(viewModel: viewModel)
+  }
+}
+
 // swiftlint:disable all
 struct SpeciesView_Previews: PreviewProvider {
-  static let vm: SpeciesViewModel = {
-    let species = loadSampleSpecies("twilek")
-    let service = MockDataService(species)
-    return SpeciesViewModel(
-      resourceId: species.speciesId,
-      dataService: service
-    )
-  }()
-
   static var previews: some View {
     NavigationView {
-      SpeciesView(viewModel: vm)
+      SpeciesView.mock
     }
   }
 }

--- a/StarWarsReader/SpeciesView/SpeciesView.swift
+++ b/StarWarsReader/SpeciesView/SpeciesView.swift
@@ -84,6 +84,7 @@ extension SpeciesView {
     let mockData = MockDataService(twilek)
     let viewModel = SpeciesViewModel(
       resourceId: twilek.speciesId,
+      filmView: { _ in FilmView.mock },
       dataService: mockData
     )
     return SpeciesView(viewModel: viewModel)

--- a/StarWarsReader/SpeciesView/SpeciesView.swift
+++ b/StarWarsReader/SpeciesView/SpeciesView.swift
@@ -85,6 +85,7 @@ extension SpeciesView {
     let viewModel = SpeciesViewModel(
       resourceId: twilek.speciesId,
       filmView: { _ in FilmView.mock },
+      personView: { _ in PersonView.mock },
       dataService: mockData
     )
     return SpeciesView(viewModel: viewModel)

--- a/StarWarsReader/SpeciesView/SpeciesView.swift
+++ b/StarWarsReader/SpeciesView/SpeciesView.swift
@@ -80,7 +80,7 @@ extension SpeciesView {
 
 extension SpeciesView {
   static var mock: SpeciesView {
-    let twilek = loadSampleSpecies("twilek")
+    let twilek = loadSampleSpecies(.twilek)
     let mockData = MockDataService(twilek)
     let viewModel = SpeciesViewModel(
       resourceId: twilek.speciesId,

--- a/StarWarsReader/SpeciesView/SpeciesViewModel.swift
+++ b/StarWarsReader/SpeciesView/SpeciesViewModel.swift
@@ -11,6 +11,8 @@ import Combine
 
 typealias SpeciesFilmView = (Species.Film) -> FilmView
 
+typealias SpeciesPersonView = (Species.Person) -> PersonView
+
 final class SpeciesViewModel: ObservableObject {
 
   private let speciesId: String
@@ -23,6 +25,8 @@ final class SpeciesViewModel: ObservableObject {
 
   private let filmView: SpeciesFilmView
 
+  private let personView: SpeciesPersonView
+
   @Published var species: Species?
 
   var people: [Species.Person] = []
@@ -32,10 +36,12 @@ final class SpeciesViewModel: ObservableObject {
   init(
     resourceId: String,
     filmView: @escaping SpeciesFilmView,
+    personView: @escaping SpeciesPersonView,
     dataService: Swapi = SwapiService()
   ) {
     speciesId = resourceId
     self.filmView = filmView
+    self.personView = personView
     self.dataService = dataService
   }
 
@@ -123,7 +129,7 @@ final class SpeciesViewModel: ObservableObject {
   }
 
   func rowViewModel(forPerson person: Species.Person) -> SpeciesPersonRowViewModel {
-    SpeciesPersonRowViewModel(person: person)
+    SpeciesPersonRowViewModel(person: person, personView: personView(person))
   }
 
   func rowViewModel(forFilm film: Species.Film) -> SpeciesFilmRowViewModel {

--- a/StarWarsReader/SpeciesView/SpeciesViewModel.swift
+++ b/StarWarsReader/SpeciesView/SpeciesViewModel.swift
@@ -9,6 +9,8 @@
 import Foundation
 import Combine
 
+typealias SpeciesFilmView = (Species.Film) -> FilmView
+
 final class SpeciesViewModel: ObservableObject {
 
   private let speciesId: String
@@ -19,6 +21,8 @@ final class SpeciesViewModel: ObservableObject {
 
   private var needsfetchSpecies = true
 
+  private let filmView: SpeciesFilmView
+
   @Published var species: Species?
 
   var people: [Species.Person] = []
@@ -27,9 +31,11 @@ final class SpeciesViewModel: ObservableObject {
 
   init(
     resourceId: String,
+    filmView: @escaping SpeciesFilmView,
     dataService: Swapi = SwapiService()
   ) {
     speciesId = resourceId
+    self.filmView = filmView
     self.dataService = dataService
   }
 
@@ -121,6 +127,6 @@ final class SpeciesViewModel: ObservableObject {
   }
 
   func rowViewModel(forFilm film: Species.Film) -> SpeciesFilmRowViewModel {
-    SpeciesFilmRowViewModel(film: film)
+    SpeciesFilmRowViewModel(film: film, filmView: filmView(film))
   }
 }

--- a/StarWarsReader/StarshipView/PilotRowView.swift
+++ b/StarWarsReader/StarshipView/PilotRowView.swift
@@ -23,7 +23,8 @@ struct PilotRowViewModel {
       homeworldView: { _ in PlanetView.mock },
       speciesView: { _ in SpeciesView.mock },
       filmView: { _ in FilmView.mock },
-      starshipView: { _ in StarshipView.mock }
+      starshipView: { _ in StarshipView.mock },
+      vehicleView: { _ in VehicleView.mock }
     )
   }
 }

--- a/StarWarsReader/StarshipView/PilotRowView.swift
+++ b/StarWarsReader/StarshipView/PilotRowView.swift
@@ -22,7 +22,8 @@ struct PilotRowViewModel {
       resourceId: pilot.pilotId,
       homeworldView: { _ in PlanetView.mock },
       speciesView: { _ in SpeciesView.mock },
-      filmView: { _ in FilmView.mock }
+      filmView: { _ in FilmView.mock },
+      starshipView: { _ in StarshipView.mock }
     )
   }
 }

--- a/StarWarsReader/StarshipView/PilotRowView.swift
+++ b/StarWarsReader/StarshipView/PilotRowView.swift
@@ -17,7 +17,8 @@ struct PilotRowViewModel {
   }
 
   var personViewModel: PersonViewModel {
-    PersonViewModel(resourceId: pilot.pilotId)
+    // TODO: refactor mock value 
+    PersonViewModel(resourceId: pilot.pilotId, homeworldView: { _ in PlanetView.mock })
   }
 }
 

--- a/StarWarsReader/StarshipView/PilotRowView.swift
+++ b/StarWarsReader/StarshipView/PilotRowView.swift
@@ -26,9 +26,7 @@ struct PilotRowView: View {
   let viewModel: PilotRowViewModel
 
   var body: some View {
-    NavigationLink(destination: PersonView(viewModel: viewModel.personViewModel)) {
-      Text(viewModel.name)
-    }
+    Text(viewModel.name)
   }
 }
 

--- a/StarWarsReader/StarshipView/PilotRowView.swift
+++ b/StarWarsReader/StarshipView/PilotRowView.swift
@@ -21,7 +21,8 @@ struct PilotRowViewModel {
     PersonViewModel(
       resourceId: pilot.pilotId,
       homeworldView: { _ in PlanetView.mock },
-      speciesView: { _ in SpeciesView.mock }
+      speciesView: { _ in SpeciesView.mock },
+      filmView: { _ in FilmView.mock }
     )
   }
 }

--- a/StarWarsReader/StarshipView/PilotRowView.swift
+++ b/StarWarsReader/StarshipView/PilotRowView.swift
@@ -33,7 +33,7 @@ struct PilotRowView: View {
 // swiftlint:disable all
 struct PilotRowView_Previews: PreviewProvider {
   static let vm: PilotRowViewModel = {
-    let falcon = loadSampleStarship("falcon")
+    let falcon = loadSampleStarship(.falcon)
     return PilotRowViewModel(pilot: falcon.pilots.first!)
   }()
 

--- a/StarWarsReader/StarshipView/PilotRowView.swift
+++ b/StarWarsReader/StarshipView/PilotRowView.swift
@@ -18,7 +18,11 @@ struct PilotRowViewModel {
 
   var personViewModel: PersonViewModel {
     // TODO: refactor mock value 
-    PersonViewModel(resourceId: pilot.pilotId, homeworldView: { _ in PlanetView.mock })
+    PersonViewModel(
+      resourceId: pilot.pilotId,
+      homeworldView: { _ in PlanetView.mock },
+      speciesView: { _ in SpeciesView.mock }
+    )
   }
 }
 

--- a/StarWarsReader/StarshipView/PilotRowView.swift
+++ b/StarWarsReader/StarshipView/PilotRowView.swift
@@ -12,20 +12,10 @@ struct PilotRowViewModel {
 
   let pilot: Starship.Pilot
 
+  let pilotView: PersonView
+
   var name: String {
     pilot.name
-  }
-
-  var personViewModel: PersonViewModel {
-    // TODO: refactor mock value 
-    PersonViewModel(
-      resourceId: pilot.pilotId,
-      homeworldView: { _ in PlanetView.mock },
-      speciesView: { _ in SpeciesView.mock },
-      filmView: { _ in FilmView.mock },
-      starshipView: { _ in StarshipView.mock },
-      vehicleView: { _ in VehicleView.mock }
-    )
   }
 }
 
@@ -34,18 +24,23 @@ struct PilotRowView: View {
   let viewModel: PilotRowViewModel
 
   var body: some View {
-    Text(viewModel.name)
+    NavigationLink(destination: viewModel.pilotView) {
+      Text(viewModel.name)
+    }
+  }
+}
+
+extension PilotRowView {
+  static var mock: PilotRowView {
+    let starshipPilot = loadSampleStarship(.falcon).pilots[0]
+    let viewModel = PilotRowViewModel(pilot: starshipPilot, pilotView: PersonView.mock)
+    return PilotRowView(viewModel: viewModel)
   }
 }
 
 // swiftlint:disable all
 struct PilotRowView_Previews: PreviewProvider {
-  static let vm: PilotRowViewModel = {
-    let falcon = loadSampleStarship(.falcon)
-    return PilotRowViewModel(pilot: falcon.pilots.first!)
-  }()
-
   static var previews: some View {
-    PilotRowView(viewModel: vm)
+    PilotRowView.mock
   }
 }

--- a/StarWarsReader/StarshipView/StarshipFilmRowView.swift
+++ b/StarWarsReader/StarshipView/StarshipFilmRowView.swift
@@ -21,7 +21,8 @@ struct StarshipFilmRowViewModel {
       filmId: film.filmId,
       // TODO: factor out these mock initializers
       characterViewInitializer: { _ in PersonView.mock },
-      characterList: { _ in CharacterListView.mock }
+      characterList: { _ in CharacterListView.mock },
+      planetView: { _ in PlanetView.mock }
     )
   }
 }

--- a/StarWarsReader/StarshipView/StarshipFilmRowView.swift
+++ b/StarWarsReader/StarshipView/StarshipFilmRowView.swift
@@ -26,7 +26,8 @@ struct StarshipFilmRowViewModel {
       filmPlanetList: { _ in FilmPlanetListView.mock },
       speciesView: { _ in SpeciesView.mock },
       filmSpeciesList: { _ in FilmSpeciesListView.mock },
-      starshipView: { _ in StarshipView.mock }
+      starshipView: { _ in StarshipView.mock },
+      filmStarshipList: { _ in FilmStarshipListView.mock }
     )
   }
 }

--- a/StarWarsReader/StarshipView/StarshipFilmRowView.swift
+++ b/StarWarsReader/StarshipView/StarshipFilmRowView.swift
@@ -25,7 +25,8 @@ struct StarshipFilmRowViewModel {
       planetView: { _ in PlanetView.mock },
       filmPlanetList: { _ in FilmPlanetListView.mock },
       speciesView: { _ in SpeciesView.mock },
-      filmSpeciesList: { _ in FilmSpeciesListView.mock }
+      filmSpeciesList: { _ in FilmSpeciesListView.mock },
+      starshipView: { _ in StarshipView.mock }
     )
   }
 }

--- a/StarWarsReader/StarshipView/StarshipFilmRowView.swift
+++ b/StarWarsReader/StarshipView/StarshipFilmRowView.swift
@@ -17,7 +17,11 @@ struct StarshipFilmRowViewModel {
   }
 
   var filmViewModel: FilmViewModel {
-    FilmViewModel(filmId: film.filmId)
+    FilmViewModel(
+      filmId: film.filmId,
+      // TODO: factor out this mock initializer 
+      characterViewInitializer: { _ in PersonView.mock }
+    )
   }
 }
 

--- a/StarWarsReader/StarshipView/StarshipFilmRowView.swift
+++ b/StarWarsReader/StarshipView/StarshipFilmRowView.swift
@@ -19,8 +19,9 @@ struct StarshipFilmRowViewModel {
   var filmViewModel: FilmViewModel {
     FilmViewModel(
       filmId: film.filmId,
-      // TODO: factor out this mock initializer 
-      characterViewInitializer: { _ in PersonView.mock }
+      // TODO: factor out these mock initializers
+      characterViewInitializer: { _ in PersonView.mock },
+      characterList: { _ in CharacterListView.mock }
     )
   }
 }

--- a/StarWarsReader/StarshipView/StarshipFilmRowView.swift
+++ b/StarWarsReader/StarshipView/StarshipFilmRowView.swift
@@ -12,25 +12,10 @@ struct StarshipFilmRowViewModel {
 
   let film: Starship.Film
 
+  let filmView: FilmView
+
   var title: String {
     film.title
-  }
-
-  var filmViewModel: FilmViewModel {
-    FilmViewModel(
-      filmId: film.filmId,
-      // TODO: factor out these mock initializers
-      characterViewInitializer: { _ in PersonView.mock },
-      characterList: { _ in CharacterListView.mock },
-      planetView: { _ in PlanetView.mock },
-      filmPlanetList: { _ in FilmPlanetListView.mock },
-      speciesView: { _ in SpeciesView.mock },
-      filmSpeciesList: { _ in FilmSpeciesListView.mock },
-      starshipView: { _ in StarshipView.mock },
-      filmStarshipList: { _ in FilmStarshipListView.mock },
-      vehicleView: { _ in VehicleView.mock },
-      filmVehicleList: { _ in FilmVehicleListView.mock }
-    )
   }
 }
 
@@ -39,18 +24,23 @@ struct StarshipFilmRowView: View {
   let viewModel: StarshipFilmRowViewModel
 
   var body: some View {
-    Text(viewModel.title)
+    NavigationLink(destination: viewModel.filmView) {
+      Text(viewModel.title)
+    }
+  }
+}
+
+extension StarshipFilmRowView {
+  static var mock: StarshipFilmRowView {
+    let starshipFilm = loadSampleStarship(.falcon).films[0]
+    let viewModel = StarshipFilmRowViewModel(film: starshipFilm, filmView: FilmView.mock)
+    return StarshipFilmRowView(viewModel: viewModel)
   }
 }
 
 // swiftlint:disable all
 struct StarshipFilmRowView_Previews: PreviewProvider {
-  static let vm: StarshipFilmRowViewModel = {
-    let falcon = loadSampleStarship(.falcon)
-    return StarshipFilmRowViewModel(film: falcon.films.first!)
-  }()
-
   static var previews: some View {
-    StarshipFilmRowView(viewModel: vm)
+    StarshipFilmRowView.mock
   }
 }

--- a/StarWarsReader/StarshipView/StarshipFilmRowView.swift
+++ b/StarWarsReader/StarshipView/StarshipFilmRowView.swift
@@ -42,7 +42,7 @@ struct StarshipFilmRowView: View {
 // swiftlint:disable all
 struct StarshipFilmRowView_Previews: PreviewProvider {
   static let vm: StarshipFilmRowViewModel = {
-    let falcon = loadSampleStarship("falcon")
+    let falcon = loadSampleStarship(.falcon)
     return StarshipFilmRowViewModel(film: falcon.films.first!)
   }()
 

--- a/StarWarsReader/StarshipView/StarshipFilmRowView.swift
+++ b/StarWarsReader/StarshipView/StarshipFilmRowView.swift
@@ -22,7 +22,8 @@ struct StarshipFilmRowViewModel {
       // TODO: factor out these mock initializers
       characterViewInitializer: { _ in PersonView.mock },
       characterList: { _ in CharacterListView.mock },
-      planetView: { _ in PlanetView.mock }
+      planetView: { _ in PlanetView.mock },
+      filmPlanetList: { _ in FilmPlanetListView.mock }
     )
   }
 }

--- a/StarWarsReader/StarshipView/StarshipFilmRowView.swift
+++ b/StarWarsReader/StarshipView/StarshipFilmRowView.swift
@@ -26,9 +26,7 @@ struct StarshipFilmRowView: View {
   let viewModel: StarshipFilmRowViewModel
 
   var body: some View {
-    NavigationLink(destination: FilmView(viewModel: viewModel.filmViewModel, navigationTag: nil)) {
-      Text(viewModel.title)
-    }
+    Text(viewModel.title)
   }
 }
 

--- a/StarWarsReader/StarshipView/StarshipFilmRowView.swift
+++ b/StarWarsReader/StarshipView/StarshipFilmRowView.swift
@@ -23,7 +23,8 @@ struct StarshipFilmRowViewModel {
       characterViewInitializer: { _ in PersonView.mock },
       characterList: { _ in CharacterListView.mock },
       planetView: { _ in PlanetView.mock },
-      filmPlanetList: { _ in FilmPlanetListView.mock }
+      filmPlanetList: { _ in FilmPlanetListView.mock },
+      speciesView: { _ in SpeciesView.mock }
     )
   }
 }

--- a/StarWarsReader/StarshipView/StarshipFilmRowView.swift
+++ b/StarWarsReader/StarshipView/StarshipFilmRowView.swift
@@ -24,7 +24,8 @@ struct StarshipFilmRowViewModel {
       characterList: { _ in CharacterListView.mock },
       planetView: { _ in PlanetView.mock },
       filmPlanetList: { _ in FilmPlanetListView.mock },
-      speciesView: { _ in SpeciesView.mock }
+      speciesView: { _ in SpeciesView.mock },
+      filmSpeciesList: { _ in FilmSpeciesListView.mock }
     )
   }
 }

--- a/StarWarsReader/StarshipView/StarshipFilmRowView.swift
+++ b/StarWarsReader/StarshipView/StarshipFilmRowView.swift
@@ -28,7 +28,8 @@ struct StarshipFilmRowViewModel {
       filmSpeciesList: { _ in FilmSpeciesListView.mock },
       starshipView: { _ in StarshipView.mock },
       filmStarshipList: { _ in FilmStarshipListView.mock },
-      vehicleView: { _ in VehicleView.mock }
+      vehicleView: { _ in VehicleView.mock },
+      filmVehicleList: { _ in FilmVehicleListView.mock }
     )
   }
 }

--- a/StarWarsReader/StarshipView/StarshipFilmRowView.swift
+++ b/StarWarsReader/StarshipView/StarshipFilmRowView.swift
@@ -27,7 +27,8 @@ struct StarshipFilmRowViewModel {
       speciesView: { _ in SpeciesView.mock },
       filmSpeciesList: { _ in FilmSpeciesListView.mock },
       starshipView: { _ in StarshipView.mock },
-      filmStarshipList: { _ in FilmStarshipListView.mock }
+      filmStarshipList: { _ in FilmStarshipListView.mock },
+      vehicleView: { _ in VehicleView.mock }
     )
   }
 }

--- a/StarWarsReader/StarshipView/StarshipView.swift
+++ b/StarWarsReader/StarshipView/StarshipView.swift
@@ -98,6 +98,7 @@ extension StarshipView {
     let viewModel = StarshipViewModel(
       resourceId: falcon.starshipId,
       pilotView: { _ in PersonView.mock },
+      filmView: { _ in FilmView.mock },
       dataService: mockData
     )
     return StarshipView(viewModel: viewModel)

--- a/StarWarsReader/StarshipView/StarshipView.swift
+++ b/StarWarsReader/StarshipView/StarshipView.swift
@@ -97,6 +97,7 @@ extension StarshipView {
     let mockData = MockDataService(falcon)
     let viewModel = StarshipViewModel(
       resourceId: falcon.starshipId,
+      pilotView: { _ in PersonView.mock },
       dataService: mockData
     )
     return StarshipView(viewModel: viewModel)

--- a/StarWarsReader/StarshipView/StarshipView.swift
+++ b/StarWarsReader/StarshipView/StarshipView.swift
@@ -91,20 +91,23 @@ extension StarshipView {
   }
 }
 
+extension StarshipView {
+  static var mock: StarshipView {
+    let falcon = loadSampleStarship("falcon")
+    let mockData = MockDataService(falcon)
+    let viewModel = StarshipViewModel(
+      resourceId: falcon.starshipId,
+      dataService: mockData
+    )
+    return StarshipView(viewModel: viewModel)
+  }
+}
+
 // swiftlint:disable all
 struct StarshipView_Previews: PreviewProvider {
-  static let vm: StarshipViewModel = {
-    let falcon = loadSampleStarship("falcon")
-    let service = MockDataService(falcon)
-    return StarshipViewModel(
-      resourceId: falcon.starshipId,
-      dataService: service
-    )
-  }()
-
   static var previews: some View {
     NavigationView {
-      StarshipView(viewModel: vm)
+      StarshipView.mock
     }
   }
 }

--- a/StarWarsReader/StarshipView/StarshipView.swift
+++ b/StarWarsReader/StarshipView/StarshipView.swift
@@ -93,7 +93,7 @@ extension StarshipView {
 
 extension StarshipView {
   static var mock: StarshipView {
-    let falcon = loadSampleStarship("falcon")
+    let falcon = loadSampleStarship(.falcon)
     let mockData = MockDataService(falcon)
     let viewModel = StarshipViewModel(
       resourceId: falcon.starshipId,

--- a/StarWarsReader/StarshipView/StarshipViewModel.swift
+++ b/StarWarsReader/StarshipView/StarshipViewModel.swift
@@ -11,6 +11,8 @@ import Combine
 
 typealias PilotView = (Starship.Pilot) -> PersonView
 
+typealias StarshipFilmView = (Starship.Film) -> FilmView
+
 final class StarshipViewModel: ObservableObject {
 
   private let formatter: NumberFormatter = {
@@ -28,7 +30,9 @@ final class StarshipViewModel: ObservableObject {
 
   private var needsStarshipData = true
 
-  private var pilotView: PilotView
+  private let pilotView: PilotView
+
+  private let filmView: StarshipFilmView
 
   @Published var starship: Starship?
 
@@ -39,10 +43,12 @@ final class StarshipViewModel: ObservableObject {
   init(
     resourceId: String,
     pilotView: @escaping PilotView,
+    filmView: @escaping StarshipFilmView,
     dataService: Swapi = SwapiService()
   ) {
     starshipId = resourceId
     self.pilotView = pilotView
+    self.filmView = filmView
     self.dataService = dataService
   }
 
@@ -153,7 +159,7 @@ final class StarshipViewModel: ObservableObject {
   }
 
   func rowViewModel(forFilm film: Starship.Film) -> StarshipFilmRowViewModel {
-    StarshipFilmRowViewModel(film: film)
+    StarshipFilmRowViewModel(film: film, filmView: filmView(film))
   }
 
   func rowViewModel(forPilot pilot: Starship.Pilot) -> PilotRowViewModel {

--- a/StarWarsReader/StarshipView/StarshipViewModel.swift
+++ b/StarWarsReader/StarshipView/StarshipViewModel.swift
@@ -9,6 +9,8 @@
 import Foundation
 import Combine
 
+typealias PilotView = (Starship.Pilot) -> PersonView
+
 final class StarshipViewModel: ObservableObject {
 
   private let formatter: NumberFormatter = {
@@ -26,6 +28,8 @@ final class StarshipViewModel: ObservableObject {
 
   private var needsStarshipData = true
 
+  private var pilotView: PilotView
+
   @Published var starship: Starship?
 
   var films: [Starship.Film] = []
@@ -34,9 +38,11 @@ final class StarshipViewModel: ObservableObject {
 
   init(
     resourceId: String,
+    pilotView: @escaping PilotView,
     dataService: Swapi = SwapiService()
   ) {
     starshipId = resourceId
+    self.pilotView = pilotView
     self.dataService = dataService
   }
 
@@ -151,6 +157,6 @@ final class StarshipViewModel: ObservableObject {
   }
 
   func rowViewModel(forPilot pilot: Starship.Pilot) -> PilotRowViewModel {
-    PilotRowViewModel(pilot: pilot)
+    PilotRowViewModel(pilot: pilot, pilotView: pilotView(pilot))
   }
 }

--- a/StarWarsReader/VehicleView/VehicleFilmRowView.swift
+++ b/StarWarsReader/VehicleView/VehicleFilmRowView.swift
@@ -21,7 +21,8 @@ struct VehicleFilmRowViewModel {
       filmId: film.filmId,
       // TODO: factor out these mock initializers
       characterViewInitializer: { _ in PersonView.mock },
-      characterList: { _ in CharacterListView.mock}
+      characterList: { _ in CharacterListView.mock},
+      planetView: { _ in PlanetView.mock }
     )
   }
 }

--- a/StarWarsReader/VehicleView/VehicleFilmRowView.swift
+++ b/StarWarsReader/VehicleView/VehicleFilmRowView.swift
@@ -27,7 +27,8 @@ struct VehicleFilmRowViewModel {
       speciesView: { _ in SpeciesView.mock },
       filmSpeciesList: { _ in FilmSpeciesListView.mock },
       starshipView: { _ in StarshipView.mock },
-      filmStarshipList: { _ in FilmStarshipListView.mock }
+      filmStarshipList: { _ in FilmStarshipListView.mock },
+      vehicleView: { _ in VehicleView.mock }
     )
   }
 }

--- a/StarWarsReader/VehicleView/VehicleFilmRowView.swift
+++ b/StarWarsReader/VehicleView/VehicleFilmRowView.swift
@@ -23,7 +23,8 @@ struct VehicleFilmRowViewModel {
       characterViewInitializer: { _ in PersonView.mock },
       characterList: { _ in CharacterListView.mock},
       planetView: { _ in PlanetView.mock },
-      filmPlanetList: { _ in FilmPlanetListView.mock }
+      filmPlanetList: { _ in FilmPlanetListView.mock },
+      speciesView: { _ in SpeciesView.mock }
     )
   }
 }

--- a/StarWarsReader/VehicleView/VehicleFilmRowView.swift
+++ b/StarWarsReader/VehicleView/VehicleFilmRowView.swift
@@ -19,8 +19,9 @@ struct VehicleFilmRowViewModel {
   var filmViewModel: FilmViewModel {
     FilmViewModel(
       filmId: film.filmId,
-      // TODO: replace mock initializer 
-      characterViewInitializer: { _ in PersonView.mock }
+      // TODO: factor out these mock initializers
+      characterViewInitializer: { _ in PersonView.mock },
+      characterList: { _ in CharacterListView.mock}
     )
   }
 }

--- a/StarWarsReader/VehicleView/VehicleFilmRowView.swift
+++ b/StarWarsReader/VehicleView/VehicleFilmRowView.swift
@@ -26,9 +26,7 @@ struct VehicleFilmRowView: View {
   let viewModel: VehicleFilmRowViewModel
 
   var body: some View {
-    NavigationLink(destination: FilmView(viewModel: viewModel.filmViewModel, navigationTag: nil)) {
-      Text(viewModel.title)
-    }
+    Text(viewModel.title)
   }
 }
 

--- a/StarWarsReader/VehicleView/VehicleFilmRowView.swift
+++ b/StarWarsReader/VehicleView/VehicleFilmRowView.swift
@@ -26,7 +26,8 @@ struct VehicleFilmRowViewModel {
       filmPlanetList: { _ in FilmPlanetListView.mock },
       speciesView: { _ in SpeciesView.mock },
       filmSpeciesList: { _ in FilmSpeciesListView.mock },
-      starshipView: { _ in StarshipView.mock }
+      starshipView: { _ in StarshipView.mock },
+      filmStarshipList: { _ in FilmStarshipListView.mock }
     )
   }
 }

--- a/StarWarsReader/VehicleView/VehicleFilmRowView.swift
+++ b/StarWarsReader/VehicleView/VehicleFilmRowView.swift
@@ -17,7 +17,11 @@ struct VehicleFilmRowViewModel {
   }
 
   var filmViewModel: FilmViewModel {
-    FilmViewModel(filmId: film.filmId)
+    FilmViewModel(
+      filmId: film.filmId,
+      // TODO: replace mock initializer 
+      characterViewInitializer: { _ in PersonView.mock }
+    )
   }
 }
 

--- a/StarWarsReader/VehicleView/VehicleFilmRowView.swift
+++ b/StarWarsReader/VehicleView/VehicleFilmRowView.swift
@@ -25,7 +25,8 @@ struct VehicleFilmRowViewModel {
       planetView: { _ in PlanetView.mock },
       filmPlanetList: { _ in FilmPlanetListView.mock },
       speciesView: { _ in SpeciesView.mock },
-      filmSpeciesList: { _ in FilmSpeciesListView.mock }
+      filmSpeciesList: { _ in FilmSpeciesListView.mock },
+      starshipView: { _ in StarshipView.mock }
     )
   }
 }

--- a/StarWarsReader/VehicleView/VehicleFilmRowView.swift
+++ b/StarWarsReader/VehicleView/VehicleFilmRowView.swift
@@ -28,7 +28,8 @@ struct VehicleFilmRowViewModel {
       filmSpeciesList: { _ in FilmSpeciesListView.mock },
       starshipView: { _ in StarshipView.mock },
       filmStarshipList: { _ in FilmStarshipListView.mock },
-      vehicleView: { _ in VehicleView.mock }
+      vehicleView: { _ in VehicleView.mock },
+      filmVehicleList: { _ in FilmVehicleListView.mock }
     )
   }
 }

--- a/StarWarsReader/VehicleView/VehicleFilmRowView.swift
+++ b/StarWarsReader/VehicleView/VehicleFilmRowView.swift
@@ -24,7 +24,8 @@ struct VehicleFilmRowViewModel {
       characterList: { _ in CharacterListView.mock},
       planetView: { _ in PlanetView.mock },
       filmPlanetList: { _ in FilmPlanetListView.mock },
-      speciesView: { _ in SpeciesView.mock }
+      speciesView: { _ in SpeciesView.mock },
+      filmSpeciesList: { _ in FilmSpeciesListView.mock }
     )
   }
 }

--- a/StarWarsReader/VehicleView/VehicleFilmRowView.swift
+++ b/StarWarsReader/VehicleView/VehicleFilmRowView.swift
@@ -42,7 +42,7 @@ struct VehicleFilmRowView: View {
 // swiftlint:disable all
 struct VehicleFilmRowView_Previews: PreviewProvider {
   static let vm: VehicleFilmRowViewModel = {
-    let airspeeder = loadSampleVehicle("airspeeder")
+    let airspeeder = loadSampleVehicle(.airspeeder)
     return VehicleFilmRowViewModel(film: airspeeder.films.first!)
   }()
 

--- a/StarWarsReader/VehicleView/VehicleFilmRowView.swift
+++ b/StarWarsReader/VehicleView/VehicleFilmRowView.swift
@@ -22,7 +22,8 @@ struct VehicleFilmRowViewModel {
       // TODO: factor out these mock initializers
       characterViewInitializer: { _ in PersonView.mock },
       characterList: { _ in CharacterListView.mock},
-      planetView: { _ in PlanetView.mock }
+      planetView: { _ in PlanetView.mock },
+      filmPlanetList: { _ in FilmPlanetListView.mock }
     )
   }
 }

--- a/StarWarsReader/VehicleView/VehicleFilmRowView.swift
+++ b/StarWarsReader/VehicleView/VehicleFilmRowView.swift
@@ -12,25 +12,10 @@ struct VehicleFilmRowViewModel {
 
   let film: Vehicle.Film
 
+  let filmView: FilmView
+
   var title: String {
     film.title
-  }
-
-  var filmViewModel: FilmViewModel {
-    FilmViewModel(
-      filmId: film.filmId,
-      // TODO: factor out these mock initializers
-      characterViewInitializer: { _ in PersonView.mock },
-      characterList: { _ in CharacterListView.mock},
-      planetView: { _ in PlanetView.mock },
-      filmPlanetList: { _ in FilmPlanetListView.mock },
-      speciesView: { _ in SpeciesView.mock },
-      filmSpeciesList: { _ in FilmSpeciesListView.mock },
-      starshipView: { _ in StarshipView.mock },
-      filmStarshipList: { _ in FilmStarshipListView.mock },
-      vehicleView: { _ in VehicleView.mock },
-      filmVehicleList: { _ in FilmVehicleListView.mock }
-    )
   }
 }
 
@@ -39,18 +24,23 @@ struct VehicleFilmRowView: View {
   let viewModel: VehicleFilmRowViewModel
 
   var body: some View {
-    Text(viewModel.title)
+    NavigationLink(destination: viewModel.filmView) {
+      Text(viewModel.title)
+    }
+  }
+}
+
+extension VehicleFilmRowView {
+  static var mock: VehicleFilmRowView {
+    let film = loadSampleVehicle(.airspeeder).films[0]
+    let viewModel = VehicleFilmRowViewModel(film: film, filmView: FilmView.mock)
+    return VehicleFilmRowView(viewModel: viewModel)
   }
 }
 
 // swiftlint:disable all
 struct VehicleFilmRowView_Previews: PreviewProvider {
-  static let vm: VehicleFilmRowViewModel = {
-    let airspeeder = loadSampleVehicle(.airspeeder)
-    return VehicleFilmRowViewModel(film: airspeeder.films.first!)
-  }()
-
   static var previews: some View {
-    VehicleFilmRowView(viewModel: vm)
+    VehicleFilmRowView.mock
   }
 }

--- a/StarWarsReader/VehicleView/VehiclePilotRowView.swift
+++ b/StarWarsReader/VehicleView/VehiclePilotRowView.swift
@@ -33,7 +33,7 @@ struct VehiclePilotRowView: View {
 // swiftlint:disable all
 struct VehiclePilotRowView_Previews: PreviewProvider {
   static let vm: VehiclePilotRowViewModel = {
-    let airspeeder = loadSampleVehicle("airspeeder")
+    let airspeeder = loadSampleVehicle(.airspeeder)
     return VehiclePilotRowViewModel(pilot: airspeeder.pilots.first!)
   }()
 

--- a/StarWarsReader/VehicleView/VehiclePilotRowView.swift
+++ b/StarWarsReader/VehicleView/VehiclePilotRowView.swift
@@ -22,7 +22,8 @@ struct VehiclePilotRowViewModel {
       resourceId: pilot.pilotId,
       homeworldView: { _ in PlanetView.mock },
       speciesView: { _ in SpeciesView.mock },
-      filmView: { _ in FilmView.mock }
+      filmView: { _ in FilmView.mock },
+      starshipView: { _ in StarshipView.mock }
     )
   }
 }

--- a/StarWarsReader/VehicleView/VehiclePilotRowView.swift
+++ b/StarWarsReader/VehicleView/VehiclePilotRowView.swift
@@ -17,7 +17,8 @@ struct VehiclePilotRowViewModel {
   }
 
   var pilotViewModel: PersonViewModel {
-    PersonViewModel(resourceId: pilot.pilotId)
+    // TODO: refactor mock value 
+    PersonViewModel(resourceId: pilot.pilotId, homeworldView: { _ in PlanetView.mock })
   }
 }
 

--- a/StarWarsReader/VehicleView/VehiclePilotRowView.swift
+++ b/StarWarsReader/VehicleView/VehiclePilotRowView.swift
@@ -18,7 +18,11 @@ struct VehiclePilotRowViewModel {
 
   var pilotViewModel: PersonViewModel {
     // TODO: refactor mock value 
-    PersonViewModel(resourceId: pilot.pilotId, homeworldView: { _ in PlanetView.mock })
+    PersonViewModel(
+      resourceId: pilot.pilotId,
+      homeworldView: { _ in PlanetView.mock },
+      speciesView: { _ in SpeciesView.mock }
+    )
   }
 }
 

--- a/StarWarsReader/VehicleView/VehiclePilotRowView.swift
+++ b/StarWarsReader/VehicleView/VehiclePilotRowView.swift
@@ -12,20 +12,10 @@ struct VehiclePilotRowViewModel {
 
   let pilot: Vehicle.Pilot
 
+  let pilotView: PersonView
+
   var name: String {
     pilot.name
-  }
-
-  var pilotViewModel: PersonViewModel {
-    // TODO: refactor mock value 
-    PersonViewModel(
-      resourceId: pilot.pilotId,
-      homeworldView: { _ in PlanetView.mock },
-      speciesView: { _ in SpeciesView.mock },
-      filmView: { _ in FilmView.mock },
-      starshipView: { _ in StarshipView.mock },
-      vehicleView: { _ in VehicleView.mock }
-    )
   }
 }
 
@@ -34,18 +24,23 @@ struct VehiclePilotRowView: View {
   let viewModel: VehiclePilotRowViewModel
 
   var body: some View {
-    Text(viewModel.name)
+    NavigationLink(destination: viewModel.pilotView) {
+      Text(viewModel.name)
+    }
+  }
+}
+
+extension VehiclePilotRowView {
+  static var mock: VehiclePilotRowView {
+    let pilot = loadSampleVehicle(.airspeeder).pilots[0]
+    let viewModel = VehiclePilotRowViewModel(pilot: pilot, pilotView: PersonView.mock)
+    return VehiclePilotRowView(viewModel: viewModel)
   }
 }
 
 // swiftlint:disable all
 struct VehiclePilotRowView_Previews: PreviewProvider {
-  static let vm: VehiclePilotRowViewModel = {
-    let airspeeder = loadSampleVehicle(.airspeeder)
-    return VehiclePilotRowViewModel(pilot: airspeeder.pilots.first!)
-  }()
-
   static var previews: some View {
-    VehiclePilotRowView(viewModel: vm)
+    VehiclePilotRowView.mock
   }
 }

--- a/StarWarsReader/VehicleView/VehiclePilotRowView.swift
+++ b/StarWarsReader/VehicleView/VehiclePilotRowView.swift
@@ -26,9 +26,7 @@ struct VehiclePilotRowView: View {
   let viewModel: VehiclePilotRowViewModel
 
   var body: some View {
-    NavigationLink(destination: PersonView(viewModel: viewModel.pilotViewModel)) {
-      Text(viewModel.name)
-    }
+    Text(viewModel.name)
   }
 }
 

--- a/StarWarsReader/VehicleView/VehiclePilotRowView.swift
+++ b/StarWarsReader/VehicleView/VehiclePilotRowView.swift
@@ -23,7 +23,8 @@ struct VehiclePilotRowViewModel {
       homeworldView: { _ in PlanetView.mock },
       speciesView: { _ in SpeciesView.mock },
       filmView: { _ in FilmView.mock },
-      starshipView: { _ in StarshipView.mock }
+      starshipView: { _ in StarshipView.mock },
+      vehicleView: { _ in VehicleView.mock }
     )
   }
 }

--- a/StarWarsReader/VehicleView/VehiclePilotRowView.swift
+++ b/StarWarsReader/VehicleView/VehiclePilotRowView.swift
@@ -21,7 +21,8 @@ struct VehiclePilotRowViewModel {
     PersonViewModel(
       resourceId: pilot.pilotId,
       homeworldView: { _ in PlanetView.mock },
-      speciesView: { _ in SpeciesView.mock }
+      speciesView: { _ in SpeciesView.mock },
+      filmView: { _ in FilmView.mock }
     )
   }
 }

--- a/StarWarsReader/VehicleView/VehicleView.swift
+++ b/StarWarsReader/VehicleView/VehicleView.swift
@@ -94,6 +94,8 @@ extension VehicleView {
     let mockData = MockDataService(airspeeder)
     let viewModel = VehicleViewModel(
       resourceId: airspeeder.vehicleId,
+      filmView: { _ in FilmView.mock },
+      pilotView: { _ in PersonView.mock},
       dataService: mockData
     )
     return VehicleView(viewModel: viewModel)

--- a/StarWarsReader/VehicleView/VehicleView.swift
+++ b/StarWarsReader/VehicleView/VehicleView.swift
@@ -90,7 +90,7 @@ extension VehicleView {
 
 extension VehicleView {
   static var mock: VehicleView {
-    let airspeeder = loadSampleVehicle("airspeeder")
+    let airspeeder = loadSampleVehicle(.airspeeder)
     let mockData = MockDataService(airspeeder)
     let viewModel = VehicleViewModel(
       resourceId: airspeeder.vehicleId,

--- a/StarWarsReader/VehicleView/VehicleView.swift
+++ b/StarWarsReader/VehicleView/VehicleView.swift
@@ -88,20 +88,23 @@ extension VehicleView {
   }
 }
 
+extension VehicleView {
+  static var mock: VehicleView {
+    let airspeeder = loadSampleVehicle("airspeeder")
+    let mockData = MockDataService(airspeeder)
+    let viewModel = VehicleViewModel(
+      resourceId: airspeeder.vehicleId,
+      dataService: mockData
+    )
+    return VehicleView(viewModel: viewModel)
+  }
+}
+
 // swiftlint:disable all
 struct VehicleView_Previews: PreviewProvider {
-  static let vm: VehicleViewModel = {
-    let airspeeder = loadSampleVehicle("airspeeder")
-    let dataSource = MockDataService(airspeeder)
-    return VehicleViewModel(
-      resourceId: airspeeder.vehicleId,
-      dataService: dataSource
-    )
-  }()
-
   static var previews: some View {
     NavigationView {
-      VehicleView(viewModel: vm)
+      VehicleView.mock
     }
   }
 }

--- a/StarWarsReader/VehicleView/VehicleViewModel.swift
+++ b/StarWarsReader/VehicleView/VehicleViewModel.swift
@@ -9,6 +9,10 @@
 import Foundation
 import Combine
 
+typealias VehicleFilmView = (Vehicle.Film) -> FilmView
+
+typealias VehiclePilotView = (Vehicle.Pilot) -> PersonView
+
 final class VehicleViewModel: ObservableObject {
 
   private let formatter: NumberFormatter = {
@@ -24,6 +28,10 @@ final class VehicleViewModel: ObservableObject {
 
   private var disposables = Set<AnyCancellable>()
 
+  private let filmView: VehicleFilmView
+
+  private let pilotView: VehiclePilotView
+
   private var needsVehicleData = true
 
   @Published var vehicle: Vehicle?
@@ -34,9 +42,13 @@ final class VehicleViewModel: ObservableObject {
 
   init(
     resourceId: String,
+    filmView: @escaping VehicleFilmView,
+    pilotView: @escaping VehiclePilotView,
     dataService: Swapi = SwapiService()
   ) {
     vehicleId = resourceId
+    self.filmView = filmView
+    self.pilotView = pilotView
     self.dataService = dataService
   }
 
@@ -137,10 +149,10 @@ final class VehicleViewModel: ObservableObject {
   }
 
   func rowViewModel(forFilm film: Vehicle.Film) -> VehicleFilmRowViewModel {
-    VehicleFilmRowViewModel(film: film)
+    VehicleFilmRowViewModel(film: film, filmView: filmView(film))
   }
 
   func rowViewModel(forPilot pilot: Vehicle.Pilot) -> VehiclePilotRowViewModel {
-    VehiclePilotRowViewModel(pilot: pilot)
+    VehiclePilotRowViewModel(pilot: pilot, pilotView: pilotView(pilot))
   }
 }

--- a/StarWarsReaderTests/FullFilmParsingTests.swift
+++ b/StarWarsReaderTests/FullFilmParsingTests.swift
@@ -42,7 +42,7 @@ class FullFilmParsingTests: XCTestCase {
   var sut: Film?
 
   override func setUp() {
-    sut = loadSampleFilm("newHope")
+    sut = loadSampleFilm(.newHope)
   }
 
   override func tearDown() {

--- a/StarWarsReaderTests/PlanetParsingTests.swift
+++ b/StarWarsReaderTests/PlanetParsingTests.swift
@@ -14,7 +14,7 @@ class PlanetParsingTests: XCTestCase {
   var sut: Planet?
 
   override func setUp() {
-    sut = loadSamplePlanet("tatooine")
+    sut = loadSamplePlanet(.tatooine)
   }
 
   override func tearDown() {

--- a/StarWarsReaderTests/SpeciesParsingTests.swift
+++ b/StarWarsReaderTests/SpeciesParsingTests.swift
@@ -14,7 +14,7 @@ class SpeciesParsingTests: XCTestCase {
   var sut: Species?
 
   override func setUp() {
-    sut = loadSampleSpecies("twilek")
+    sut = loadSampleSpecies(.twilek)
   }
 
   override func tearDown() {

--- a/StarWarsReaderTests/StarshipParsingTests.swift
+++ b/StarWarsReaderTests/StarshipParsingTests.swift
@@ -14,7 +14,7 @@ class StarshipParsingTests: XCTestCase {
   var sut: Starship?
 
   override func setUp() {
-    sut = loadSampleStarship("falcon")
+    sut = loadSampleStarship(.falcon)
   }
 
   override func tearDown() {

--- a/StarWarsReaderTests/VehicleParsingTests.swift
+++ b/StarWarsReaderTests/VehicleParsingTests.swift
@@ -14,7 +14,7 @@ class VehicleParsingTests: XCTestCase {
   var sut: Vehicle?
 
   override func setUp() {
-    sut = loadSampleVehicle("airspeeder")
+    sut = loadSampleVehicle(.airspeeder)
   }
 
   override func tearDown() {


### PR DESCRIPTION
PR includes a major refactor of how the app handles navigation. 

Previously views and view models worked together to instantiate new views for navigation link destinations. Typically, a view model would vend the destination view model and the view would pass the instantiated view to the `NavigationLink`. 

In order to separate responsibilities, a new `FlowCoordinator` is now responsible for vending any destination views and injecting those as closures to the view model. 

In addition, there's some light refactoring of how sample data is requested for previews, using enums in place of of raw strings. 